### PR TITLE
Update TicketMessage.php

### DIFF
--- a/Entity/TicketMessage.php
+++ b/Entity/TicketMessage.php
@@ -306,12 +306,18 @@ class TicketMessage
     {
         $this->ticket = $ticket;
 
-        // if null, then new ticket
-        if (\is_null($ticket->getUserCreated())) {
-            $ticket->setUserCreated($this->getUser());
+        if (\is_null($this->getUserObject())) {
+            $user = $this->getUser();
+        } else {
+            $user = $this->getUserObject();
         }
 
-        $ticket->setLastUser($this->getUser());
+        // if null, then new ticket
+        if (\is_null($ticket->getUserCreated())) {
+            $ticket->setUserCreated($user);
+        }
+
+        $ticket->setLastUser($user);
         $ticket->setLastMessage($this->getCreatedAt());
         $ticket->setPriority($this->getPriority());
 


### PR DESCRIPTION
Pass an User Object instead of User ID when updating/creating a new ticket. User Object could be used later in some events (for example, in TicketEvents::TICKET_CREATE when creating a new ticket).