### PR TITLE
fix Call to a member function hasRole() when showing ticket posted by…

### DIFF
--- a/Extension/UserExtension.php
+++ b/Extension/UserExtension.php
@@ -24,7 +24,10 @@ class UserExtension extends \Twig_Extension
             $user = $this->userManager->getUserById($user);
         }
 
-        return $user->hasRole($role);
+        if (is_object($user))
+            return $user->hasRole($role);
+        else
+            return false;
     }
 
     public function getName()


### PR DESCRIPTION
An error occurs when we try to display a ticket posted by an anonymous user which is not an existing user object.