### PR TITLE
UserLoad listener to ignore non bundle entites

### DIFF
--- a/EventListener/UserLoad.php
+++ b/EventListener/UserLoad.php
@@ -25,6 +25,12 @@ class UserLoad
     public function postLoad(LifecycleEventArgs $args)
     {
         $entity = $args->getEntity();
+        
+        // Ignore any entity lifecycle events not relating to this bundles entities.
+        if(!$entity instanceof Ticket && !$entity instanceof TicketMessage){
+            return;
+        }
+        
         $userRepository = $args->getEntityManager()->getRepository($this->userRepository);
 
         if ($entity instanceof Ticket) {


### PR DESCRIPTION
The listener causes issues any entity is loaded from a different entity manager other than default.

The listener should ignore any entity which is not part of this bundle.