### PR TITLE
Make "symfony/*" dependencies explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != hhvm && -f xdebug.ini ]]; then phpenv config-rm xdebug.ini; fi
   - if [ "$GITHUB_OAUTH_TOKEN" != "" ]; then echo -e $GITHUB_OAUTH_TOKEN && composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS

--- a/composer.json
+++ b/composer.json
@@ -26,25 +26,37 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/symfony": "^2.8 || ^3.0 || ^4.0",
-        "sensio/framework-extra-bundle": "^3.0.2 || ^4.0",
+        "doctrine/doctrine-bundle": "^1.4",
         "doctrine/orm": "^2.4.8",
-        "doctrine/doctrine-bundle": "~1.4",
-        "knplabs/knp-paginator-bundle": "~2.3"
+        "knplabs/knp-paginator-bundle": "^2.3",
+        "sensio/framework-extra-bundle": "^3.0.2 || ^4.0",
+        "symfony/config": "^2.8 || ^3.0 || ^4.0",
+        "symfony/console": "^2.8 || ^3.0 || ^4.0",
+        "symfony/dependency-injection": "^2.8 || ^3.0 || ^4.0",
+        "symfony/event-dispatcher": "^2.8 || ^3.0 || ^4.0",
+        "symfony/form": "^2.8 || ^3.0 || ^4.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
+        "symfony/http-foundation": "^2.8 || ^3.0 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0",
+        "symfony/options-resolver": "^2.8 || ^3.0 || ^4.0",
+        "symfony/validator": "^2.8 || ^3.0 || ^4.0"
     },
     "suggest": {
         "vich/uploader-bundle": "Allow attaching files to ticket messages"
     },
     "require-dev": {
-        "symfony/form": "^2.8 || ^3.0 || ^4.0",
-        "symfony/phpunit-bridge": "^2.8 || ^3.0 || ^4.0",
         "phpunit/phpunit": "^5.4",
-        "sllh/php-cs-fixer-styleci-bridge": "^1.5"
+        "sllh/php-cs-fixer-styleci-bridge": "^1.5",
+        "symfony/phpunit-bridge": "^2.8 || ^3.0 || ^4.0",
+        "symfony/security": "^2.8 || ^3.0 || ^4.0"
     },
     "autoload": {
         "psr-4": {
             "Hackzilla\\Bundle\\TicketBundle\\": ""
         }
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |
                      

Flex applications mark "symfony/symfony" as conflicting dependency. See https://symfony.com/doc/current/setup/flex.html#upgrading-existing-applications-to-flex.