### PR TITLE
[dependencies] Provide "translation" service via "symfony/translation" instead of "sensio/framework-extra-bundle"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,24 +17,25 @@ matrix:
   fast_finish: true
   include:
     - php: 5.6
+      env: SYMFONY_PHPUNIT_VERSION="5.7.27"
     - php: 5.6
-      env: COMPOSER_FLAGS="--prefer-lowest"
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_PHPUNIT_VERSION="5.7.27"
     - php: 5.6
-      env: SYMFONY_VERSION="~2.8.0"
+      env: SYMFONY_VERSION="~2.8.0" SYMFONY_PHPUNIT_VERSION="5.7.27"
     - php: 5.6
-      env: SYMFONY_VERSION="~3.0.0"
+      env: SYMFONY_VERSION="~3.0.0" SYMFONY_PHPUNIT_VERSION="5.7.27"
     - php: 5.6
-      env: SYMFONY_VERSION="~3.1.0"
+      env: SYMFONY_VERSION="~3.1.0" SYMFONY_PHPUNIT_VERSION="5.7.27"
     - php: 5.6
-      env: SYMFONY_VERSION="~3.2.0"
+      env: SYMFONY_VERSION="~3.2.0" SYMFONY_PHPUNIT_VERSION="5.7.27"
     - php: 5.6
-      env: INSTALL_VICH_UPLOADER_BUNDLE=true
+      env: INSTALL_VICH_UPLOADER_BUNDLE=true SYMFONY_PHPUNIT_VERSION="5.7.27"
     - php: 7.2
-      env: SYMFONY_VERSION="^4.1@dev"
+      env: SYMFONY_VERSION="^4.2@dev" SYMFONY_PHPUNIT_VERSION="7.4.4"
   allow_failures:
     - php: nightly
     - php: hhvm
-    - env: SYMFONY_VERSION="^4.1@dev"
+    - env: SYMFONY_VERSION="^4.2@dev" SYMFONY_PHPUNIT_VERSION="7.4.4"
 
 sudo: false
 
@@ -47,7 +48,7 @@ before_script:
   - if [ "$GITHUB_OAUTH_TOKEN" != "" ]; then echo -e $GITHUB_OAUTH_TOKEN && composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [ -n $INSTALL_VICH_UPLOADER_BUNDLE ]; then composer require "vich/uploader-bundle" --no-update; fi;
-  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+  - COMPOSER_MEMORY_LIMIT=-1 composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
   - if [[ -n $INSTALL_VICH_UPLOADER_BUNDLE ]]; then make test_with_vichuploaderbundle; else make test; fi;

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "doctrine/doctrine-bundle": "^1.4",
         "doctrine/orm": "^2.4.8",
         "knplabs/knp-paginator-bundle": "^2.3",
-        "sensio/framework-extra-bundle": "^3.0.2 || ^4.0",
         "symfony/config": "^2.8 || ^3.0 || ^4.0",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.0 || ^4.0",
@@ -40,6 +39,7 @@
         "symfony/http-kernel": "^2.8 || ^3.0 || ^4.0",
         "symfony/options-resolver": "^2.8 || ^3.0 || ^4.0",
         "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0",
+        "symfony/translation": "^2.8 || ^3.0 || ^4.0",
         "symfony/validator": "^2.8 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.8 || ^3.0 || ^4.0"
     },
@@ -53,6 +53,7 @@
         "phpunit/phpunit": "<5.4.3"
     },
     "suggest": {
+        "friendsofsymfony/user-bundle": "In order to ease user management",
         "vich/uploader-bundle": "Allow attaching files to ticket messages"
     },
     "autoload": {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

* Provide "translation" service via "symfony/translation" instead of "sensio/framework-extra-bundle";
* Declare "SYMFONY_PHPUNIT_VERSION" at CI tests in order to avoid issues with nonexistent PHPUnit branches (see symfony/symfony#29265, sebastianbergmann/phpunit#3413).