### PR TITLE
Some minor changes at `TicketManager`

### DIFF
--- a/Controller/TicketController.php
+++ b/Controller/TicketController.php
@@ -33,7 +33,7 @@ class TicketController extends Controller
         $ticketState    = $request->get('state', $this->get('translator')->trans('STATUS_OPEN', [], 'HackzillaTicketBundle'));
         $ticketPriority = $request->get('priority', null);
 
-        $query = $ticketManager->getTicketList(
+        $query = $ticketManager->getTicketListQuery(
             $userManager,
             $ticketManager->getTicketStatus($ticketState),
             $ticketManager->getTicketPriority($ticketPriority)

--- a/Manager/TicketManager.php
+++ b/Manager/TicketManager.php
@@ -105,8 +105,6 @@ class TicketManager implements TicketManagerInterface
      *
      * @param TicketInterface        $ticket
      * @param TicketMessageInterface $message
-     *
-     * @return TicketInterface
      */
     public function updateTicket(TicketInterface $ticket, TicketMessageInterface $message = null)
     {
@@ -118,14 +116,12 @@ class TicketManager implements TicketManagerInterface
             $this->objectManager->persist($message);
         }
         $this->objectManager->flush();
-
-        return $ticket;
     }
 
     /**
      * Delete a ticket from the database.
      *
-     * @param TicketInterface $ticket*
+     * @param TicketInterface $ticket
      */
     public function deleteTicket(TicketInterface $ticket)
     {
@@ -180,13 +176,9 @@ class TicketManager implements TicketManagerInterface
     }
 
     /**
-     * @param UserManagerInterface $userManager
-     * @param int                  $ticketStatus
-     * @param int                  $ticketPriority
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
-    public function getTicketList(UserManagerInterface $userManager, $ticketStatus, $ticketPriority = null)
+    public function getTicketListQuery(UserManagerInterface $userManager, $ticketStatus, $ticketPriority = null)
     {
         $query = $this->ticketRepository->createQueryBuilder('t')
 //            ->select($this->ticketClass.' t')

--- a/Manager/TicketManagerInterface.php
+++ b/Manager/TicketManagerInterface.php
@@ -34,9 +34,9 @@ interface TicketManagerInterface
      * @param int                  $ticketStatus
      * @param int                  $ticketPriority
      *
-     * @return mixed
+     * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getTicketList(UserManagerInterface $userManager, $ticketStatus, $ticketPriority = null);
+    public function getTicketListQuery(UserManagerInterface $userManager, $ticketStatus, $ticketPriority = null);
 
     /**
      * @param int $days

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -4,3 +4,10 @@ UPGRADE FROM 2.x to 3.0
  * Translation catalogues were renamed from "messages" to "HackzillaTicketBundle"
    in order to allow projects consuming this bundle to override them in a proper
    way.
+
+ * Renamed method `TicketManagerInterface::getTicketList()` to `TicketManagerInterface::getTicketListQuery()`
+   to clarify what it returns.
+
+ * `TicketManagerInterface::updateTicket()` now returns `void`, since the object
+   (`TicketInterface`) it was returning before is the same as the provided in its
+   argument 1.


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |yes   |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

* Renamed method `TicketManagerInterface::getTicketList()` to `TicketManagerInterface::getTicketListQuery()`
    to clarify what it returns;
* `TicketManagerInterface::updateTicket()` now returns `void`, since the object (`TicketInterface`) it was returning before is the same as the provided in its argument 1.
