### PR TITLE
Fix service injection at argument 3 for `AutoClosingCommand::__construct()`

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -82,7 +82,7 @@ services:
         arguments:
             - '@hackzilla_ticket.ticket_manager'
             - '@hackzilla_ticket.user_manager'
-            - '@doctrine'
+            - '@doctrine.orm.entity_manager'
             - '@translator'
             # BC: Replace 5th argument with "@parameter_bag" after bumping "symfony/dependency-injection" to "^4.1"
             - '@service_container'

--- a/Tests/Functional/Command/ApplicationTest.php
+++ b/Tests/Functional/Command/ApplicationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Hackzilla\Bundle\TicketBundle\Tests\Functional\Command;
+
+use Hackzilla\Bundle\TicketBundle\Tests\Functional\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class ApplicationTest extends WebTestCase
+{
+    /**
+     * @dataProvider getCommands
+     *
+     * @param string $commandName
+     */
+    public function testCommandRegistration($commandName)
+    {
+        $this->markTestSkipped('"friendsofsymfony/user-bundle" must be installed in order to run this test');
+
+        $application = new Application(static::$kernel);
+
+        $this->assertInstanceOf(Command::class, $application->find($commandName));
+    }
+
+    public function getCommands()
+    {
+        return [
+            ['ticket:autoclosing'],
+            ['ticket:create'],
+        ];
+    }
+}


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a  |