### PR TITLE
Make explicit dependency against "twig/twig" in order to replace usage of `spaceless` tag, which is deprecated since "1.38"

### DIFF
--- a/Resources/views/Macros/macros.html.twig
+++ b/Resources/views/Macros/macros.html.twig
@@ -1,5 +1,5 @@
 {% macro status_btn(status, text, small = false) %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if status == 10 %}
             <button class="btn btn-warning {{ small ? 'btn-xs' : '' }} disabled active"><span
                         class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ text|upper }}</button>
@@ -19,11 +19,11 @@
             <button class="btn btn-danger {{ small ? 'btn-xs' : '' }} disabled active"><span
                         class="glyphicon glyphicon-folder-close"></span>&nbsp;&nbsp;{{ text|upper }}</button>
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 {% macro status_alert(status, text) %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if status == 10 %}
             <div class="alert alert-warning" role="alert"><span class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, 'HackzillaTicketBundle') }}
             </div>
@@ -46,11 +46,11 @@
             <div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-folder-close"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, 'HackzillaTicketBundle') }}
             </div>
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 {% macro priority_btn(priority, text, small = false) %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if priority <= 20 %}
             <button class="btn btn-info {{ small ? 'btn-xs' : '' }} disabled active">{{ text|upper }}</button>
         {% elseif priority == 21 %}
@@ -60,11 +60,11 @@
             <button class="btn btn-danger {{ small ? 'btn-xs' : '' }} disabled active"><span
                         class="glyphicon glyphicon-asterisk"></span>&nbsp;&nbsp;{{ text|upper }}</button>
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 {% macro priority_alert(priority, text) %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if priority <= 20 %}
             <div class="alert alert-info"
                  role="alert">{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }, 'HackzillaTicketBundle') }}</div>
@@ -77,12 +77,12 @@
                         class="glyphicon glyphicon-star"></span>&nbsp;&nbsp;{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }, 'HackzillaTicketBundle') }}
             </div>
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 {# Source: http://stackoverflow.com/a/15303004/157656 #}
 {% macro bytesToSize(bytes) %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% set kilobyte = 1024 %}
         {% set megabyte = kilobyte * 1024 %}
         {% set gigabyte = megabyte * 1024 %}
@@ -99,5 +99,5 @@
         {% else %}
             {{ (bytes / terabyte)|number_format(2, '.') ~ ' TB' }}
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "conflict": {
         "phpunit/phpunit": "<5.4.3",
-        "twig/twig": "<1.34"
+        "twig/twig": "<2.9"
     },
     "suggest": {
         "friendsofsymfony/user-bundle": "In order to ease user management",


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

- Make explicit dependency against  "twig/twig:^2.9";
- Changed usages of `{% spaceless %}` tag, which is deprecated as of Twig 1.38 with `{% apply spaceless %}` filter, which is available as of Twig 2.9.