### PR TITLE
Replace "twig/twig" requirement with "symfony/twig-bundle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,9 @@
         "symfony/options-resolver": "^2.8 || ^3.0 || ^4.0",
         "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0",
         "symfony/translation": "^2.8 || ^3.0 || ^4.0",
+        "symfony/twig-bundle": "^2.8 || ^3.0 || ^4.0",
         "symfony/validator": "^2.8 || ^3.0 || ^4.0",
-        "symfony/yaml": "^2.8 || ^3.0 || ^4.0",
-        "twig/twig": "^1.34 || ^2.0"
+        "symfony/yaml": "^2.8 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
@@ -51,7 +51,8 @@
         "symfony/security": "^2.8 || ^3.0 || ^4.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<5.4.3"
+        "phpunit/phpunit": "<5.4.3",
+        "twig/twig": "<1.34"
     },
     "suggest": {
         "friendsofsymfony/user-bundle": "In order to ease user management",


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

* "symfony/twig-bundle" is required to call `render()` from controllers;
* "twig/twig" was moved to `conflict` section with the constraint `<1.34` in order to ensure its namespaced classes are available.