### PR TITLE
Add tests for templates load

### DIFF
--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -6,6 +6,7 @@ use Hackzilla\Bundle\TicketBundle\Entity\Ticket;
 use Hackzilla\Bundle\TicketBundle\Entity\TicketMessage;
 use Hackzilla\Bundle\TicketBundle\Manager\TicketManagerInterface;
 use Hackzilla\Bundle\TicketBundle\Tests\Functional\Entity\User;
+use Twig\Template;
 use Vich\UploaderBundle\Event\Events;
 
 /**
@@ -55,5 +56,12 @@ class FunctionalTest extends WebTestCase
         $listeners       = $eventDispatcher->getListeners();
 
         $this->assertArrayHasKey(Events::POST_UPLOAD, $listeners);
+    }
+
+    public function testTemplateLoad()
+    {
+        $twig = static::$kernel->getContainer()->get('twig');
+
+        $this->assertInstanceOf(Template::class, $twig->loadTemplate('@HackzillaTicket/Ticket/index.html.twig'));
     }
 }

--- a/Tests/Functional/Resources/views/base.html.twig
+++ b/Tests/Functional/Resources/views/base.html.twig
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{% block title %}HackzillaTicketBundle{% endblock %}</title>
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+    </body>
+</html>

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -5,9 +5,11 @@ namespace Hackzilla\Bundle\TicketBundle\Tests\Functional;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Hackzilla\Bundle\TicketBundle\HackzillaTicketBundle;
 use Hackzilla\Bundle\TicketBundle\Tests\Functional\Entity\User;
+use Knp\Bundle\PaginatorBundle\KnpPaginatorBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
@@ -39,6 +41,8 @@ class TestKernel extends Kernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new DoctrineBundle(),
+            new KnpPaginatorBundle(),
+            new TwigBundle(),
             new HackzillaTicketBundle(),
             new TestBundle(),
         ];

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^5.6 || ^7.0",
         "doctrine/doctrine-bundle": "^1.4",
         "doctrine/orm": "^2.4.8",
-        "knplabs/knp-paginator-bundle": "^2.3 || ^3.0 || ^4.0",
+        "knplabs/knp-paginator-bundle": "^2.6 || ^3.0 || ^4.0",
         "symfony/config": "^2.8 || ^3.0 || ^4.0",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.0 || ^4.0",


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

Requirement for "knplabs/knp-paginator-bundle" was updated [from `^2.3` to `^2.6`](https://github.com/KnpLabs/KnpPaginatorBundle/compare/v2.3.2...v2.6.0#diff-0a26006f70eb61548221c2dd5b0c15f2L40), since versions previous to `v2.6.0` were using the service "templating.helper.router", which is not registered within the current dependencies.