### PR TITLE
Update constraint for "phpunit/phpunit"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,11 @@
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "friendsofphp/php-cs-fixer": "^1.4 || ^2.0",
+        "phpunit/phpunit": ">=5.4.3,<8.0",
         "symfony/phpunit-bridge": "^3.2 || ^4.0",
         "symfony/security": "^2.8 || ^3.0 || ^4.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<5.4.3",
         "twig/twig": "<1.34"
     },
     "suggest": {


### PR DESCRIPTION
Update constraint for "phpunit/phpunit" in order to avoid conflicts when the package is installed as a 3rd party dependency.