### PR TITLE
Explicitly require "twig/twig" since it is used by the Twig ticket extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/translation": "^2.8 || ^3.0 || ^4.0",
         "symfony/twig-bundle": "^2.8 || ^3.0 || ^4.0",
         "symfony/validator": "^2.8 || ^3.0 || ^4.0",
-        "symfony/yaml": "^2.8 || ^3.0 || ^4.0"
+        "symfony/yaml": "^2.8 || ^3.0 || ^4.0",
+        "twig/twig": "^1.34 || ^2.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
@@ -50,9 +51,6 @@
         "phpunit/phpunit": ">=5.4.3,<8.0",
         "symfony/phpunit-bridge": "^3.2 || ^4.0",
         "symfony/security": "^2.8 || ^3.0 || ^4.0"
-    },
-    "conflict": {
-        "twig/twig": "<1.34"
     },
     "suggest": {
         "friendsofsymfony/user-bundle": "In order to ease user management",


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

This partially reverts #146.