### PR TITLE
Deprecate "messages" translation domain in favor of "HackzillaTicketBundle" (backport PR #123)

### DIFF
--- a/Command/AutoClosingCommand.php
+++ b/Command/AutoClosingCommand.php
@@ -49,6 +49,8 @@ class AutoClosingCommand extends ContainerAwareCommand
         $translator = $this->getContainer()->get('translator');
         $translator->setLocale($locale);
 
+        $translationDomain = $this->getContainer()->getParameter('hackzilla_ticket.translation_domain');
+
         $username = $input->getArgument('username');
 
         $resolved_tickets = $ticketRepository->getResolvedTicketOlderThan($input->getOption('age'));
@@ -56,7 +58,7 @@ class AutoClosingCommand extends ContainerAwareCommand
         foreach ($resolved_tickets as $ticket) {
             $message = $ticket_manager->createMessage()
                 ->setMessage(
-                    $translator->trans('MESSAGE_STATUS_CHANGED', ['%status%' => $translator->trans('STATUS_CLOSED')])
+                    $translator->trans('MESSAGE_STATUS_CHANGED', ['%status%' => $translator->trans('STATUS_CLOSED', [], $translationDomain)], $translationDomain)
                 )
                 ->setStatus(TicketMessage::STATUS_CLOSED)
                 ->setPriority($ticket->getPriority())

--- a/Controller/TicketAttachmentController.php
+++ b/Controller/TicketAttachmentController.php
@@ -25,7 +25,9 @@ class TicketAttachmentController extends Controller
         $ticketMessage = $ticketManager->getMessageById($ticketMessageId);
 
         if (!$ticketMessage || !$ticketMessage instanceof TicketMessageWithAttachment) {
-            throw $this->createNotFoundException($this->get('translator')->trans('ERROR_FIND_TICKET_ENTITY'));
+            $translationDomain = $this->getParameter('hackzilla_ticket.translation_domain');
+
+            throw $this->createNotFoundException($this->get('translator')->trans('ERROR_FIND_TICKET_ENTITY', [], $translationDomain));
         }
 
         // check permissions

--- a/Controller/TicketController.php
+++ b/Controller/TicketController.php
@@ -30,7 +30,9 @@ class TicketController extends Controller
         $userManager   = $this->getUserManager();
         $ticketManager = $this->get('hackzilla_ticket.ticket_manager');
 
-        $ticketState    = $request->get('state', $this->get('translator')->trans('STATUS_OPEN'));
+        $translationDomain = $this->getParameter('hackzilla_ticket.translation_domain');
+
+        $ticketState    = $request->get('state', $this->get('translator')->trans('STATUS_OPEN', [], $translationDomain));
         $ticketPriority = $request->get('priority', null);
 
         $query = $ticketManager->getTicketListQuery(
@@ -48,9 +50,10 @@ class TicketController extends Controller
         return $this->render(
             $this->container->getParameter('hackzilla_ticket.templates')['index'],
             [
-                'pagination'     => $pagination,
-                'ticketState'    => $ticketState,
-                'ticketPriority' => $ticketPriority,
+                'pagination'        => $pagination,
+                'ticketState'       => $ticketState,
+                'ticketPriority'    => $ticketPriority,
+                'translationDomain' => $translationDomain,
             ]
         );
     }
@@ -81,11 +84,14 @@ class TicketController extends Controller
             return $this->redirect($this->generateUrl('hackzilla_ticket_show', ['ticketId' => $ticket->getId()]));
         }
 
+        $translationDomain = $this->getParameter('hackzilla_ticket.translation_domain');
+
         return $this->render(
             $this->container->getParameter('hackzilla_ticket.templates')['new'],
             [
-                'entity' => $ticket,
-                'form'   => $form->createView(),
+                'entity'            => $ticket,
+                'form'              => $form->createView(),
+                'translationDomain' => $translationDomain,
             ]
         );
     }
@@ -100,11 +106,14 @@ class TicketController extends Controller
 
         $form = $this->createForm(TicketType::class, $entity);
 
+        $translationDomain = $this->getParameter('hackzilla_ticket.translation_domain');
+
         return $this->render(
             $this->container->getParameter('hackzilla_ticket.templates')['new'],
             [
-                'entity' => $entity,
-                'form'   => $form->createView(),
+                'entity'            => $entity,
+                'form'              => $form->createView(),
+                'translationDomain' => $translationDomain,
             ]
         );
     }
@@ -128,7 +137,9 @@ class TicketController extends Controller
         $currentUser = $this->getUserManager()->getCurrentUser();
         $this->getUserManager()->hasPermission($currentUser, $ticket);
 
-        $data = ['ticket' => $ticket];
+        $translationDomain = $this->getParameter('hackzilla_ticket.translation_domain');
+
+        $data = ['ticket' => $ticket, 'translationDomain' => $translationDomain];
 
         $message = $ticketManager->createMessage($ticket);
 
@@ -156,8 +167,10 @@ class TicketController extends Controller
         $ticketManager = $this->get('hackzilla_ticket.ticket_manager');
         $ticket        = $ticketManager->getTicketById($ticketId);
 
+        $translationDomain = $this->getParameter('hackzilla_ticket.translation_domain');
+
         if (!$ticket) {
-            throw $this->createNotFoundException($this->get('translator')->trans('ERROR_FIND_TICKET_ENTITY'));
+            throw $this->createNotFoundException($this->get('translator')->trans('ERROR_FIND_TICKET_ENTITY', [], $translationDomain));
         }
 
         $user = $this->getUserManager()->getCurrentUser();
@@ -176,7 +189,7 @@ class TicketController extends Controller
             return $this->redirect($this->generateUrl('hackzilla_ticket_show', ['ticketId' => $ticket->getId()]));
         }
 
-        $data = ['ticket' => $ticket, 'form' => $form->createView()];
+        $data = ['ticket' => $ticket, 'form' => $form->createView(), 'translationDomain' => $translationDomain];
 
         if ($user && $this->get('hackzilla_ticket.user_manager')->hasRole($user, TicketRole::ADMIN)) {
             $data['delete_form'] = $this->createDeleteForm($ticket->getId())->createView();
@@ -212,7 +225,9 @@ class TicketController extends Controller
                 $ticket        = $ticketManager->getTicketById($ticketId);
 
                 if (!$ticket) {
-                    throw $this->createNotFoundException($this->get('translator')->trans('ERROR_FIND_TICKET_ENTITY'));
+                    $translationDomain = $this->getParameter('hackzilla_ticket.translation_domain');
+
+                    throw $this->createNotFoundException($this->get('translator')->trans('ERROR_FIND_TICKET_ENTITY', [], $translationDomain));
                 }
 
                 $ticketManager->deleteTicket($ticket);
@@ -264,8 +279,6 @@ class TicketController extends Controller
      */
     private function getUserManager()
     {
-        $userManager = $this->get('hackzilla_ticket.user_manager');
-
-        return $userManager;
+        return $this->get('hackzilla_ticket.user_manager');
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,10 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->enumNode('translation_domain')
+                    ->values(['HackzillaTicketBundle', 'messages'])
+                    ->defaultValue('messages')
+                ->end()
                 ->scalarNode('user_class')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('ticket_class')->cannotBeEmpty()->defaultValue('Hackzilla\Bundle\TicketBundle\Entity\Ticket')->end()
                 ->scalarNode('message_class')->cannotBeEmpty()->defaultValue('Hackzilla\Bundle\TicketBundle\Entity\TicketMessage')->end()

--- a/DependencyInjection/HackzillaTicketExtension.php
+++ b/DependencyInjection/HackzillaTicketExtension.php
@@ -37,10 +37,30 @@ class HackzillaTicketExtension extends Extension
         if (!isset($bundles['VichUploaderBundle'])) {
             $container->removeDefinition('hackzilla_ticket.file_upload_subscriber');
         }
+
+        $this->setTranslationDomain($config, $container);
     }
 
     public static function bundleDirectory()
     {
         return realpath(__DIR__.'/..');
+    }
+
+    private function setTranslationDomain(array $config, ContainerBuilder $container)
+    {
+        $translationDomain = $config['translation_domain'];
+
+        if ('HackzillaTicketBundle' !== $translationDomain) {
+            @trigger_error(
+                'Omitting the option "hackzilla_ticket.translation_domain" or using other value than "HackzillaTicketBundle" is deprecated since hackzilla/ticket-bundle 3.3.'
+                .' This option will be removed in version 4.0 and the only supported translation domain will be "HackzillaTicketBundle".',
+                E_USER_DEPRECATED
+            );
+        }
+
+        $container->setParameter('hackzilla_ticket.translation_domain', $translationDomain);
+
+        $definition = $container->getDefinition('hackzilla_ticket.ticket_manager');
+        $definition->addMethodCall('setTranslationDomain', [$translationDomain]);
     }
 }

--- a/Manager/TicketManager.php
+++ b/Manager/TicketManager.php
@@ -13,6 +13,13 @@ class TicketManager implements TicketManagerInterface
 {
     private $translator;
 
+    /**
+     * NEXT_MAJOR: Remove this property and replace its usages with "HackzillaTicketBundle".
+     *
+     * @var string
+     */
+    private $translationDomain = 'messages';
+
     private $objectManager;
 
     private $ticketRepository;
@@ -57,6 +64,20 @@ class TicketManager implements TicketManagerInterface
     public function setTranslator(TranslatorInterface $translator)
     {
         $this->translator = $translator;
+
+        return $this;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @param string $translationDomain
+     *
+     * @return $this
+     */
+    public function setTranslationDomain($translationDomain)
+    {
+        $this->translationDomain = $translationDomain;
 
         return $this;
     }
@@ -279,7 +300,7 @@ class TicketManager implements TicketManagerInterface
             $statuses = [];
 
             foreach (TicketMessageInterface::STATUSES as $id => $value) {
-                $statuses[$id] = $this->translator->trans($value);
+                $statuses[$id] = $this->translator->trans($value, [], $this->translationDomain);
             }
         }
 
@@ -301,7 +322,7 @@ class TicketManager implements TicketManagerInterface
             $priorities = [];
 
             foreach (TicketMessageInterface::PRIORITIES as $id => $value) {
-                $priorities[$id] = $this->translator->trans($value);
+                $priorities[$id] = $this->translator->trans($value, [], $this->translationDomain);
             }
         }
 

--- a/Resources/translations/HackzillaTicketBundle.de.xlf
+++ b/Resources/translations/HackzillaTicketBundle.de.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="status_open">
+        <source>STATUS_OPEN</source>
+        <target>geöffnet</target>
+      </trans-unit>
+      <trans-unit id="status_in_progress">
+        <source>STATUS_IN_PROGRESS</source>
+        <target>im Gange</target>
+      </trans-unit>
+      <trans-unit id="status_information_requested">
+        <source>STATUS_INFORMATION_REQUESTED</source>
+        <target>Informationen angefordert</target>
+      </trans-unit>
+      <trans-unit id="status_on_hold">
+        <source>STATUS_ON_HOLD</source>
+        <target>in Wartestellung</target>
+      </trans-unit>
+      <trans-unit id="status_resolved">
+        <source>STATUS_RESOLVED</source>
+        <target>gelöst</target>
+      </trans-unit>
+      <trans-unit id="status_closed">
+        <source>STATUS_CLOSED</source>
+        <target>geschlossen</target>
+      </trans-unit>
+      <trans-unit id="priority_low">
+        <source>PRIORITY_LOW</source>
+        <target>gering</target>
+      </trans-unit>
+      <trans-unit id="priority_medium">
+        <source>PRIORITY_MEDIUM</source>
+        <target>mittel</target>
+      </trans-unit>
+      <trans-unit id="priority_high">
+        <source>PRIORITY_HIGH</source>
+        <target>hoch</target>
+      </trans-unit>
+      <trans-unit id="status_invalid">
+        <source>STATUS_INVALID</source>
+        <target>ungültig</target>
+      </trans-unit>
+      <trans-unit id="priority_invalid">
+        <source>PRIORITY_INVALID</source>
+        <target>ungültig</target>
+      </trans-unit>
+      <trans-unit id="heading_subject">
+        <source>HEADING_SUBJECT</source>
+        <target>Thema</target>
+      </trans-unit>
+      <trans-unit id="heading_status">
+        <source>HEADING_STATUS</source>
+        <target>Zustand</target>
+      </trans-unit>
+      <trans-unit id="heading_priority">
+        <source>HEADING_PRIORITY</source>
+        <target>Dringlichkeit</target>
+      </trans-unit>
+      <trans-unit id="heading_modified">
+        <source>HEADING_MODIFIED</source>
+        <target>geändert am</target>
+      </trans-unit>
+      <trans-unit id="heading_created">
+        <source>HEADING_CREATED</source>
+        <target>eröffnet am</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_list">
+        <source>HEADING_TICKET_LIST</source>
+        <target>Liste der Tickets</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket">
+        <source>HEADING_TICKET</source>
+        <target>Aufgabe</target>
+      </trans-unit>
+      <trans-unit id="heading_new_ticket">
+        <source>HEADING_NEW_TICKET</source>
+        <target>Neues Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_id">
+        <source>HEADING_TICKET_ID</source>
+        <target>Ticket nº%id%</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_thread">
+        <source>HEADING_TICKET_THREAD</source>
+        <target>Unterhaltung</target>
+      </trans-unit>
+      <trans-unit id="heading_last_message_by">
+        <source>HEADING_LAST_MESSAGE_BY</source>
+        <target>Vorige Nachricht von</target>
+      </trans-unit>
+      <trans-unit id="heading_last_modified">
+        <source>HEADING_LAST_MODIFIED</source>
+        <target>Vorige Änderung</target>
+      </trans-unit>
+      <trans-unit id="heading_author">
+        <source>HEADING_AUTHOR</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="button_delete">
+        <source>BUTTON_DELETE</source>
+        <target>löschen</target>
+      </trans-unit>
+      <trans-unit id="button_back_to_list">
+        <source>BUTTON_BACK_TO_LIST</source>
+        <target>Zurück zur Liste</target>
+      </trans-unit>
+      <trans-unit id="button_update">
+        <source>BUTTON_UPDATE</source>
+        <target>aktualisieren</target>
+      </trans-unit>
+      <trans-unit id="button_create">
+        <source>BUTTON_CREATE</source>
+        <target>Erstellen</target>
+      </trans-unit>
+      <trans-unit id="button_new">
+        <source>BUTTON_NEW</source>
+        <target>Neues Ticket</target>
+      </trans-unit>
+      <trans-unit id="button_toggle_state">
+        <source>BUTTON_TOGGLE_STATE</source>
+        <target>Zeige das Ticket %state%s</target>
+      </trans-unit>
+      <trans-unit id="label_author">
+        <source>LABEL_AUTHOR</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="label_date">
+        <source>LABEL_DATE</source>
+        <target>Datum</target>
+      </trans-unit>
+      <trans-unit id="label_priority">
+        <source>LABEL_PRIORITY</source>
+        <target>Dringlichkeit</target>
+      </trans-unit>
+      <trans-unit id="label_status">
+        <source>LABEL_STATUS</source>
+        <target>Zustand</target>
+      </trans-unit>
+      <trans-unit id="label_message">
+        <source>LABEL_MESSAGE</source>
+        <target>Nachricht</target>
+      </trans-unit>
+      <trans-unit id="label_created">
+        <source>LABEL_CREATED</source>
+        <target>erstellt am</target>
+      </trans-unit>
+      <trans-unit id="label_created_by">
+        <source>LABEL_CREATED_BY</source>
+        <target>erstellt von</target>
+      </trans-unit>
+      <trans-unit id="label_admin">
+        <source>LABEL_ADMIN</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="label_mark_solved">
+        <source>LABEL_MARK_SOLVED</source>
+        <target>identifizieren als gelöst</target>
+      </trans-unit>
+      <trans-unit id="label_enter_details">
+        <source>LABEL_ENTER_DETAILS</source>
+        <target>Details hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="label_enter_subject">
+        <source>LABEL_ENTER_SUBJECT</source>
+        <target>Thema hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="label_subject">
+        <source>LABEL_SUBJECT</source>
+        <target>Thema</target>
+      </trans-unit>
+      <trans-unit id="label_date_format">
+        <source>LABEL_DATE_FORMAT</source>
+        <target>d.m.Y</target>
+      </trans-unit>
+      <trans-unit id="label_date_time_format">
+        <source>LABEL_DATE_TIME_FORMAT</source>
+        <target>H:i:s d.m.Y</target>
+      </trans-unit>
+      <trans-unit id="message_no_tickets">
+        <source>MESSAGE_NO_TICKETS</source>
+        <target>Kein Ticket gefunden</target>
+      </trans-unit>
+      <trans-unit id="message_empty">
+        <source>MESSAGE_EMPTY</source>
+        <target>-- Keine Nachricht --</target>
+      </trans-unit>
+      <trans-unit id="message_ticket_opened">
+        <source>MESSAGE_TICKET_OPENED</source>
+        <target>Ticket mit %priority% Dringlichkeit begonnen.</target>
+      </trans-unit>
+      <trans-unit id="message_status_changed">
+        <source>MESSAGE_STATUS_CHANGED</source>
+        <target>Zustand geändert: %status%.</target>
+      </trans-unit>
+      <trans-unit id="message_priority_changed">
+        <source>MESSAGE_PRIORITY_CHANGED</source>
+        <target>Dringlichkeit geändert: %priority%.</target>
+      </trans-unit>
+      <trans-unit id="error_find_ticket_entity">
+        <source>ERROR_FIND_TICKET_ENTITY</source>
+        <target>Ticket unmöglich zu finden.</target>
+      </trans-unit>
+      <trans-unit id="label_ticket_attachment">
+        <source>LABEL_ATTACHMENT</source>
+        <target>Anhang</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/translations/HackzillaTicketBundle.en.xlf
+++ b/Resources/translations/HackzillaTicketBundle.en.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="status_open">
+        <source>STATUS_OPEN</source>
+        <target>open</target>
+      </trans-unit>
+      <trans-unit id="status_in_progress">
+        <source>STATUS_IN_PROGRESS</source>
+        <target>in progress</target>
+      </trans-unit>
+      <trans-unit id="status_information_requested">
+        <source>STATUS_INFORMATION_REQUESTED</source>
+        <target>information requested</target>
+      </trans-unit>
+      <trans-unit id="status_on_hold">
+        <source>STATUS_ON_HOLD</source>
+        <target>on hold</target>
+      </trans-unit>
+      <trans-unit id="status_resolved">
+        <source>STATUS_RESOLVED</source>
+        <target>resolved</target>
+      </trans-unit>
+      <trans-unit id="status_closed">
+        <source>STATUS_CLOSED</source>
+        <target>closed</target>
+      </trans-unit>
+      <trans-unit id="priority_low">
+        <source>PRIORITY_LOW</source>
+        <target>low</target>
+      </trans-unit>
+      <trans-unit id="priority_medium">
+        <source>PRIORITY_MEDIUM</source>
+        <target>medium</target>
+      </trans-unit>
+      <trans-unit id="priority_high">
+        <source>PRIORITY_HIGH</source>
+        <target>high</target>
+      </trans-unit>
+      <trans-unit id="status_invalid">
+        <source>STATUS_INVALID</source>
+        <target>invalid</target>
+      </trans-unit>
+      <trans-unit id="priority_invalid">
+        <source>PRIORITY_INVALID</source>
+        <target>invalid</target>
+      </trans-unit>
+      <trans-unit id="heading_subject">
+        <source>HEADING_SUBJECT</source>
+        <target>Subject</target>
+      </trans-unit>
+      <trans-unit id="heading_status">
+        <source>HEADING_STATUS</source>
+        <target>Status</target>
+      </trans-unit>
+      <trans-unit id="heading_priority">
+        <source>HEADING_PRIORITY</source>
+        <target>Priority</target>
+      </trans-unit>
+      <trans-unit id="heading_modified">
+        <source>HEADING_MODIFIED</source>
+        <target>Modified</target>
+      </trans-unit>
+      <trans-unit id="heading_created">
+        <source>HEADING_CREATED</source>
+        <target>Created</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_list">
+        <source>HEADING_TICKET_LIST</source>
+        <target>Ticket list</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket">
+        <source>HEADING_TICKET</source>
+        <target>Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_new_ticket">
+        <source>HEADING_NEW_TICKET</source>
+        <target>New Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_id">
+        <source>HEADING_TICKET_ID</source>
+        <target>Ticket #%id%</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_thread">
+        <source>HEADING_TICKET_THREAD</source>
+        <target>Ticket Thread</target>
+      </trans-unit>
+      <trans-unit id="heading_last_message_by">
+        <source>HEADING_LAST_MESSAGE_BY</source>
+        <target>Last Message By</target>
+      </trans-unit>
+      <trans-unit id="heading_last_modified">
+        <source>HEADING_LAST_MODIFIED</source>
+        <target>Last Modified</target>
+      </trans-unit>
+      <trans-unit id="heading_author">
+        <source>HEADING_AUTHOR</source>
+        <target>Author</target>
+      </trans-unit>
+      <trans-unit id="button_delete">
+        <source>BUTTON_DELETE</source>
+        <target>Delete</target>
+      </trans-unit>
+      <trans-unit id="button_back_to_list">
+        <source>BUTTON_BACK_TO_LIST</source>
+        <target>Back to list</target>
+      </trans-unit>
+      <trans-unit id="button_update">
+        <source>BUTTON_UPDATE</source>
+        <target>Update</target>
+      </trans-unit>
+      <trans-unit id="button_create">
+        <source>BUTTON_CREATE</source>
+        <target>Create</target>
+      </trans-unit>
+      <trans-unit id="button_new">
+        <source>BUTTON_NEW</source>
+        <target>New Ticket</target>
+      </trans-unit>
+      <trans-unit id="button_toggle_state">
+        <source>BUTTON_TOGGLE_STATE</source>
+        <target>Show %state% tickets</target>
+      </trans-unit>
+      <trans-unit id="label_author">
+        <source>LABEL_AUTHOR</source>
+        <target>Author</target>
+      </trans-unit>
+      <trans-unit id="label_date">
+        <source>LABEL_DATE</source>
+        <target>Date</target>
+      </trans-unit>
+      <trans-unit id="label_priority">
+        <source>LABEL_PRIORITY</source>
+        <target>Priority</target>
+      </trans-unit>
+      <trans-unit id="label_status">
+        <source>LABEL_STATUS</source>
+        <target>Status</target>
+      </trans-unit>
+      <trans-unit id="label_message">
+        <source>LABEL_MESSAGE</source>
+        <target>Message</target>
+      </trans-unit>
+      <trans-unit id="label_created">
+        <source>LABEL_CREATED</source>
+        <target>Created</target>
+      </trans-unit>
+      <trans-unit id="label_created_by">
+        <source>LABEL_CREATED_BY</source>
+        <target>Created by</target>
+      </trans-unit>
+      <trans-unit id="label_admin">
+        <source>LABEL_ADMIN</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="label_mark_solved">
+        <source>LABEL_MARK_SOLVED</source>
+        <target>Mark solved</target>
+      </trans-unit>
+      <trans-unit id="label_enter_details">
+        <source>LABEL_ENTER_DETAILS</source>
+        <target>Enter details</target>
+      </trans-unit>
+      <trans-unit id="label_enter_subject">
+        <source>LABEL_ENTER_SUBJECT</source>
+        <target>Enter subject</target>
+      </trans-unit>
+      <trans-unit id="label_subject">
+        <source>LABEL_SUBJECT</source>
+        <target>Subject</target>
+      </trans-unit>
+      <trans-unit id="label_date_format">
+        <source>LABEL_DATE_FORMAT</source>
+        <target>m/d/Y</target>
+      </trans-unit>
+      <trans-unit id="label_date_time_format">
+        <source>LABEL_DATE_TIME_FORMAT</source>
+        <target>m/d/Y H:i:s</target>
+      </trans-unit>
+      <trans-unit id="message_no_tickets">
+        <source>MESSAGE_NO_TICKETS</source>
+        <target>No tickets found</target>
+      </trans-unit>
+      <trans-unit id="message_empty">
+        <source>MESSAGE_EMPTY</source>
+        <target>-- Message was empty --</target>
+      </trans-unit>
+      <trans-unit id="message_ticket_opened">
+        <source>MESSAGE_TICKET_OPENED</source>
+        <target>Ticket opened with priority: %priority%.</target>
+      </trans-unit>
+      <trans-unit id="message_status_changed">
+        <source>MESSAGE_STATUS_CHANGED</source>
+        <target>Status was changed to %status%.</target>
+      </trans-unit>
+      <trans-unit id="message_priority_changed">
+        <source>MESSAGE_PRIORITY_CHANGED</source>
+        <target>Priority was changed to %priority%.</target>
+      </trans-unit>
+      <trans-unit id="error_find_ticket_entity">
+        <source>ERROR_FIND_TICKET_ENTITY</source>
+        <target>Unable to find Ticket entity.</target>
+      </trans-unit>
+      <trans-unit id="label_ticket_attachment">
+        <source>LABEL_ATTACHMENT</source>
+        <target>Attachment</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/translations/HackzillaTicketBundle.es.xlf
+++ b/Resources/translations/HackzillaTicketBundle.es.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="status_open">
+        <source>STATUS_OPEN</source>
+        <target>Empezado</target>
+      </trans-unit>
+      <trans-unit id="status_in_progress">
+        <source>STATUS_IN_PROGRESS</source>
+        <target>En marcha</target>
+      </trans-unit>
+      <trans-unit id="status_information_requested">
+        <source>STATUS_INFORMATION_REQUESTED</source>
+        <target>Información solicitada</target>
+      </trans-unit>
+      <trans-unit id="status_on_hold">
+        <source>STATUS_ON_HOLD</source>
+        <target>En espera</target>
+      </trans-unit>
+      <trans-unit id="status_resolved">
+        <source>STATUS_RESOLVED</source>
+        <target>Resuelto</target>
+      </trans-unit>
+      <trans-unit id="status_closed">
+        <source>STATUS_CLOSED</source>
+        <target>Terminado</target>
+      </trans-unit>
+      <trans-unit id="priority_low">
+        <source>PRIORITY_LOW</source>
+        <target>Baja</target>
+      </trans-unit>
+      <trans-unit id="priority_medium">
+        <source>PRIORITY_MEDIUM</source>
+        <target>Media</target>
+      </trans-unit>
+      <trans-unit id="priority_high">
+        <source>PRIORITY_HIGH</source>
+        <target>Alta</target>
+      </trans-unit>
+      <trans-unit id="status_invalid">
+        <source>STATUS_INVALID</source>
+        <target>Inválido</target>
+      </trans-unit>
+      <trans-unit id="priority_invalid">
+        <source>PRIORITY_INVALID</source>
+        <target>Inválido</target>
+      </trans-unit>
+      <trans-unit id="heading_subject">
+        <source>HEADING_SUBJECT</source>
+        <target>Tema</target>
+      </trans-unit>
+      <trans-unit id="heading_status">
+        <source>HEADING_STATUS</source>
+        <target>Estado</target>
+      </trans-unit>
+      <trans-unit id="heading_priority">
+        <source>HEADING_PRIORITY</source>
+        <target>Prioridad</target>
+      </trans-unit>
+      <trans-unit id="heading_modified">
+        <source>HEADING_MODIFIED</source>
+        <target>Modificado el</target>
+      </trans-unit>
+      <trans-unit id="heading_created">
+        <source>HEADING_CREATED</source>
+        <target>Creado el</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_list">
+        <source>HEADING_TICKET_LIST</source>
+        <target>Lista de las tareas</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket">
+        <source>HEADING_TICKET</source>
+        <target>Tarea</target>
+      </trans-unit>
+      <trans-unit id="heading_new_ticket">
+        <source>HEADING_NEW_TICKET</source>
+        <target>Nueva tarea</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_id">
+        <source>HEADING_TICKET_ID</source>
+        <target>Tarea nº%id%</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_thread">
+        <source>HEADING_TICKET_THREAD</source>
+        <target>Diálogo</target>
+      </trans-unit>
+      <trans-unit id="heading_last_message_by">
+        <source>HEADING_LAST_MESSAGE_BY</source>
+        <target>Último mensaje de parte de</target>
+      </trans-unit>
+      <trans-unit id="heading_last_modified">
+        <source>HEADING_LAST_MODIFIED</source>
+        <target>Último modificación de parte de </target>
+      </trans-unit>
+      <trans-unit id="heading_author">
+        <source>HEADING_AUTHOR</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="button_delete">
+        <source>BUTTON_DELETE</source>
+        <target>Suprimir</target>
+      </trans-unit>
+      <trans-unit id="button_back_to_list">
+        <source>BUTTON_BACK_TO_LIST</source>
+        <target>Volver a la lista</target>
+      </trans-unit>
+      <trans-unit id="button_update">
+        <source>BUTTON_UPDATE</source>
+        <target>Actualizar</target>
+      </trans-unit>
+      <trans-unit id="button_create">
+        <source>BUTTON_CREATE</source>
+        <target>Crear</target>
+      </trans-unit>
+      <trans-unit id="button_new">
+        <source>BUTTON_NEW</source>
+        <target>Nueva tarea</target>
+      </trans-unit>
+      <trans-unit id="button_toggle_state">
+        <source>BUTTON_TOGGLE_STATE</source>
+        <target>Mostrar las tareas %state%s</target>
+      </trans-unit>
+      <trans-unit id="label_author">
+        <source>LABEL_AUTHOR</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="label_date">
+        <source>LABEL_DATE</source>
+        <target>Fecha</target>
+      </trans-unit>
+      <trans-unit id="label_priority">
+        <source>LABEL_PRIORITY</source>
+        <target>Prioridad</target>
+      </trans-unit>
+      <trans-unit id="label_status">
+        <source>LABEL_STATUS</source>
+        <target>Estado</target>
+      </trans-unit>
+      <trans-unit id="label_message">
+        <source>LABEL_MESSAGE</source>
+        <target>Mensaje</target>
+      </trans-unit>
+      <trans-unit id="label_created">
+        <source>LABEL_CREATED</source>
+        <target>Creado el</target>
+      </trans-unit>
+      <trans-unit id="label_created_by">
+        <source>LABEL_CREATED_BY</source>
+        <target>Creado por</target>
+      </trans-unit>
+      <trans-unit id="label_admin">
+        <source>LABEL_ADMIN</source>
+        <target>Administrador</target>
+      </trans-unit>
+      <trans-unit id="label_mark_solved">
+        <source>LABEL_MARK_SOLVED</source>
+        <target>Identificar como resuelto</target>
+      </trans-unit>
+      <trans-unit id="label_enter_details">
+        <source>LABEL_ENTER_DETAILS</source>
+        <target>Ingrese algunos detalles</target>
+      </trans-unit>
+      <trans-unit id="label_enter_subject">
+        <source>LABEL_ENTER_SUBJECT</source>
+        <target>Ingrese el tema</target>
+      </trans-unit>
+      <trans-unit id="label_subject">
+        <source>LABEL_SUBJECT</source>
+        <target>Tema</target>
+      </trans-unit>
+      <trans-unit id="label_date_format">
+        <source>LABEL_DATE_FORMAT</source>
+        <target>Y/m/d</target>
+      </trans-unit>
+      <trans-unit id="label_date_time_format">
+        <source>LABEL_DATE_TIME_FORMAT</source>
+        <target>Y/m/d H:i:s</target>
+      </trans-unit>
+      <trans-unit id="message_no_tickets">
+        <source>MESSAGE_NO_TICKETS</source>
+        <target>No hay tareas</target>
+      </trans-unit>
+      <trans-unit id="message_empty">
+        <source>MESSAGE_EMPTY</source>
+        <target>-- Mensaje vacío --</target>
+      </trans-unit>
+      <trans-unit id="message_ticket_opened">
+        <source>MESSAGE_TICKET_OPENED</source>
+        <target>Tarea creada como %priority% prioridad .</target>
+      </trans-unit>
+      <trans-unit id="message_status_changed">
+        <source>MESSAGE_STATUS_CHANGED</source>
+        <target>Estado modificado: %status%.</target>
+      </trans-unit>
+      <trans-unit id="message_priority_changed">
+        <source>MESSAGE_PRIORITY_CHANGED</source>
+        <target>Prioridad modificado: %priority%.</target>
+      </trans-unit>
+      <trans-unit id="error_find_ticket_entity">
+        <source>ERROR_FIND_TICKET_ENTITY</source>
+        <target> Ninguna tarea encontrado.</target>
+      </trans-unit>
+      <trans-unit id="label_ticket_attachment">
+        <source>LABEL_ATTACHMENT</source>
+        <target>Adjunto</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/translations/HackzillaTicketBundle.fr.xlf
+++ b/Resources/translations/HackzillaTicketBundle.fr.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="status_open">
+        <source>STATUS_OPEN</source>
+        <target>ouvert</target>
+      </trans-unit>
+      <trans-unit id="status_in_progress">
+        <source>STATUS_IN_PROGRESS</source>
+        <target>en cours</target>
+      </trans-unit>
+      <trans-unit id="status_information_requested">
+        <source>STATUS_INFORMATION_REQUESTED</source>
+        <target>Informations demandées</target>
+      </trans-unit>
+      <trans-unit id="status_on_hold">
+        <source>STATUS_ON_HOLD</source>
+        <target>en attente</target>
+      </trans-unit>
+      <trans-unit id="status_resolved">
+        <source>STATUS_RESOLVED</source>
+        <target>résolu</target>
+      </trans-unit>
+      <trans-unit id="status_closed">
+        <source>STATUS_CLOSED</source>
+        <target>fermé</target>
+      </trans-unit>
+      <trans-unit id="priority_low">
+        <source>PRIORITY_LOW</source>
+        <target>basse</target>
+      </trans-unit>
+      <trans-unit id="priority_medium">
+        <source>PRIORITY_MEDIUM</source>
+        <target>moyenne</target>
+      </trans-unit>
+      <trans-unit id="priority_high">
+        <source>PRIORITY_HIGH</source>
+        <target>haute</target>
+      </trans-unit>
+      <trans-unit id="status_invalid">
+        <source>STATUS_INVALID</source>
+        <target>nul</target>
+      </trans-unit>
+      <trans-unit id="priority_invalid">
+        <source>PRIORITY_INVALID</source>
+        <target>nul</target>
+      </trans-unit>
+      <trans-unit id="heading_subject">
+        <source>HEADING_SUBJECT</source>
+        <target>Objet</target>
+      </trans-unit>
+      <trans-unit id="heading_status">
+        <source>HEADING_STATUS</source>
+        <target>Condition</target>
+      </trans-unit>
+      <trans-unit id="heading_priority">
+        <source>HEADING_PRIORITY</source>
+        <target>Priorité</target>
+      </trans-unit>
+      <trans-unit id="heading_modified">
+        <source>HEADING_MODIFIED</source>
+        <target>Modifié le</target>
+      </trans-unit>
+      <trans-unit id="heading_created">
+        <source>HEADING_CREATED</source>
+        <target>Créé le</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_list">
+        <source>HEADING_TICKET_LIST</source>
+        <target>Liste des tickets</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket">
+        <source>HEADING_TICKET</source>
+        <target>Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_new_ticket">
+        <source>HEADING_NEW_TICKET</source>
+        <target>Nouveau Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_id">
+        <source>HEADING_TICKET_ID</source>
+        <target>Ticket nº%id%</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_thread">
+        <source>HEADING_TICKET_THREAD</source>
+        <target>Fil de discussion</target>
+      </trans-unit>
+      <trans-unit id="heading_last_message_by">
+        <source>HEADING_LAST_MESSAGE_BY</source>
+        <target>Dernier message par</target>
+      </trans-unit>
+      <trans-unit id="heading_last_modified">
+        <source>HEADING_LAST_MODIFIED</source>
+        <target>Dernière modification</target>
+      </trans-unit>
+      <trans-unit id="heading_author">
+        <source>HEADING_AUTHOR</source>
+        <target>Auteur</target>
+      </trans-unit>
+      <trans-unit id="button_delete">
+        <source>BUTTON_DELETE</source>
+        <target>Supprimer</target>
+      </trans-unit>
+      <trans-unit id="button_back_to_list">
+        <source>BUTTON_BACK_TO_LIST</source>
+        <target>Retour à la liste</target>
+      </trans-unit>
+      <trans-unit id="button_update">
+        <source>BUTTON_UPDATE</source>
+        <target>Mettre à jour</target>
+      </trans-unit>
+      <trans-unit id="button_create">
+        <source>BUTTON_CREATE</source>
+        <target>Créer</target>
+      </trans-unit>
+      <trans-unit id="button_new">
+        <source>BUTTON_NEW</source>
+        <target>Nouveau Ticket</target>
+      </trans-unit>
+      <trans-unit id="button_toggle_state">
+        <source>BUTTON_TOGGLE_STATE</source>
+        <target>Montrer les tickets %state%s</target>
+      </trans-unit>
+      <trans-unit id="label_author">
+        <source>LABEL_AUTHOR</source>
+        <target>Auteur</target>
+      </trans-unit>
+      <trans-unit id="label_date">
+        <source>LABEL_DATE</source>
+        <target>Date</target>
+      </trans-unit>
+      <trans-unit id="label_priority">
+        <source>LABEL_PRIORITY</source>
+        <target>Priorité</target>
+      </trans-unit>
+      <trans-unit id="label_status">
+        <source>LABEL_STATUS</source>
+        <target>Condition</target>
+      </trans-unit>
+      <trans-unit id="label_message">
+        <source>LABEL_MESSAGE</source>
+        <target>Message</target>
+      </trans-unit>
+      <trans-unit id="label_created">
+        <source>LABEL_CREATED</source>
+        <target>Créé le</target>
+      </trans-unit>
+      <trans-unit id="label_created_by">
+        <source>LABEL_CREATED_BY</source>
+        <target>Créé par</target>
+      </trans-unit>
+      <trans-unit id="label_admin">
+        <source>LABEL_ADMIN</source>
+        <target>Admin</target>
+      </trans-unit>
+      <trans-unit id="label_mark_solved">
+        <source>LABEL_MARK_SOLVED</source>
+        <target>Marquer comme résolu</target>
+      </trans-unit>
+      <trans-unit id="label_enter_details">
+        <source>LABEL_ENTER_DETAILS</source>
+        <target>Ajouter des détails</target>
+      </trans-unit>
+      <trans-unit id="label_enter_subject">
+        <source>LABEL_ENTER_SUBJECT</source>
+        <target>Entrez objet</target>
+      </trans-unit>
+      <trans-unit id="label_subject">
+        <source>LABEL_SUBJECT</source>
+        <target>objet</target>
+      </trans-unit>
+      <trans-unit id="label_date_format">
+        <source>LABEL_DATE_FORMAT</source>
+        <target>d/m/Y</target>
+      </trans-unit>
+      <trans-unit id="label_date_time_format">
+        <source>LABEL_DATE_TIME_FORMAT</source>
+        <target>d/m/Y H:i:s</target>
+      </trans-unit>
+      <trans-unit id="message_no_tickets">
+        <source>MESSAGE_NO_TICKETS</source>
+        <target>Aucun ticket trouvé</target>
+      </trans-unit>
+      <trans-unit id="message_empty">
+        <source>MESSAGE_EMPTY</source>
+        <target>-- Message vide --</target>
+      </trans-unit>
+      <trans-unit id="message_ticket_opened">
+        <source>MESSAGE_TICKET_OPENED</source>
+        <target>Ticket ouvert avec la priorité: %priority%.</target>
+      </trans-unit>
+      <trans-unit id="message_status_changed">
+        <source>MESSAGE_STATUS_CHANGED</source>
+        <target>Condition modifiée pour %status%.</target>
+      </trans-unit>
+      <trans-unit id="message_priority_changed">
+        <source>MESSAGE_PRIORITY_CHANGED</source>
+        <target>Priorité modifiée pour %priority%.</target>
+      </trans-unit>
+      <trans-unit id="error_find_ticket_entity">
+        <source>ERROR_FIND_TICKET_ENTITY</source>
+        <target>Impossible de recupérer les tickets.</target>
+      </trans-unit>
+      <trans-unit id="label_ticket_attachment">
+        <source>LABEL_ATTACHMENT</source>
+        <target>Pièce jointe</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/translations/HackzillaTicketBundle.it.xlf
+++ b/Resources/translations/HackzillaTicketBundle.it.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="status_open">
+        <source>STATUS_OPEN</source>
+        <target>aperto</target>
+      </trans-unit>
+      <trans-unit id="status_in_progress">
+        <source>STATUS_IN_PROGRESS</source>
+        <target>in avanzamento</target>
+      </trans-unit>
+      <trans-unit id="status_information_requested">
+        <source>STATUS_INFORMATION_REQUESTED</source>
+        <target>richieste informazioni</target>
+      </trans-unit>
+      <trans-unit id="status_on_hold">
+        <source>STATUS_ON_HOLD</source>
+        <target>in attesa</target>
+      </trans-unit>
+      <trans-unit id="status_resolved">
+        <source>STATUS_RESOLVED</source>
+        <target>risolto</target>
+      </trans-unit>
+      <trans-unit id="status_closed">
+        <source>STATUS_CLOSED</source>
+        <target>chiuso</target>
+      </trans-unit>
+      <trans-unit id="priority_low">
+        <source>PRIORITY_LOW</source>
+        <target>bassa</target>
+      </trans-unit>
+      <trans-unit id="priority_medium">
+        <source>PRIORITY_MEDIUM</source>
+        <target>media</target>
+      </trans-unit>
+      <trans-unit id="priority_high">
+        <source>PRIORITY_HIGH</source>
+        <target>alta</target>
+      </trans-unit>
+      <trans-unit id="status_invalid">
+        <source>STATUS_INVALID</source>
+        <target>invalido</target>
+      </trans-unit>
+      <trans-unit id="priority_invalid">
+        <source>PRIORITY_INVALID</source>
+        <target>invalida</target>
+      </trans-unit>
+      <trans-unit id="heading_subject">
+        <source>HEADING_SUBJECT</source>
+        <target>Oggetto</target>
+      </trans-unit>
+      <trans-unit id="heading_status">
+        <source>HEADING_STATUS</source>
+        <target>Status</target>
+      </trans-unit>
+      <trans-unit id="heading_priority">
+        <source>HEADING_PRIORITY</source>
+        <target>Priorità</target>
+      </trans-unit>
+      <trans-unit id="heading_modified">
+        <source>HEADING_MODIFIED</source>
+        <target>Modificato</target>
+      </trans-unit>
+      <trans-unit id="heading_created">
+        <source>HEADING_CREATED</source>
+        <target>Creato</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_list">
+        <source>HEADING_TICKET_LIST</source>
+        <target>Lista Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket">
+        <source>HEADING_TICKET</source>
+        <target>Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_new_ticket">
+        <source>HEADING_NEW_TICKET</source>
+        <target>Nuovo Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_id">
+        <source>HEADING_TICKET_ID</source>
+        <target>Ticket #%id%</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_thread">
+        <source>HEADING_TICKET_THREAD</source>
+        <target>Discussione del Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_last_message_by">
+        <source>HEADING_LAST_MESSAGE_BY</source>
+        <target>Ultimo Messaggio Di</target>
+      </trans-unit>
+      <trans-unit id="heading_last_modified">
+        <source>HEADING_LAST_MODIFIED</source>
+        <target>Ultima Modifica</target>
+      </trans-unit>
+      <trans-unit id="heading_author">
+        <source>HEADING_AUTHOR</source>
+        <target>Autore</target>
+      </trans-unit>
+      <trans-unit id="button_delete">
+        <source>BUTTON_DELETE</source>
+        <target>Elimina</target>
+      </trans-unit>
+      <trans-unit id="button_back_to_list">
+        <source>BUTTON_BACK_TO_LIST</source>
+        <target>Torna alla lista</target>
+      </trans-unit>
+      <trans-unit id="button_update">
+        <source>BUTTON_UPDATE</source>
+        <target>Aggiorna</target>
+      </trans-unit>
+      <trans-unit id="button_create">
+        <source>BUTTON_CREATE</source>
+        <target>Crea</target>
+      </trans-unit>
+      <trans-unit id="button_new">
+        <source>BUTTON_NEW</source>
+        <target>Nuovo Ticket</target>
+      </trans-unit>
+      <trans-unit id="button_toggle_state">
+        <source>BUTTON_TOGGLE_STATE</source>
+        <target>Vedi %state% ticket</target>
+      </trans-unit>
+      <trans-unit id="label_author">
+        <source>LABEL_AUTHOR</source>
+        <target>Autore</target>
+      </trans-unit>
+      <trans-unit id="label_date">
+        <source>LABEL_DATE</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="label_priority">
+        <source>LABEL_PRIORITY</source>
+        <target>Priorità</target>
+      </trans-unit>
+      <trans-unit id="label_status">
+        <source>LABEL_STATUS</source>
+        <target>Status</target>
+      </trans-unit>
+      <trans-unit id="label_message">
+        <source>LABEL_MESSAGE</source>
+        <target>Messaggio</target>
+      </trans-unit>
+      <trans-unit id="label_created">
+        <source>LABEL_CREATED</source>
+        <target>Creato</target>
+      </trans-unit>
+      <trans-unit id="label_created_by">
+        <source>LABEL_CREATED_BY</source>
+        <target>Creato da</target>
+      </trans-unit>
+      <trans-unit id="label_admin">
+        <source>LABEL_ADMIN</source>
+        <target>Amministratore</target>
+      </trans-unit>
+      <trans-unit id="label_mark_solved">
+        <source>LABEL_MARK_SOLVED</source>
+        <target>Segna come risolto</target>
+      </trans-unit>
+      <trans-unit id="label_enter_details">
+        <source>LABEL_ENTER_DETAILS</source>
+        <target>Inserisci i dettagli</target>
+      </trans-unit>
+      <trans-unit id="label_enter_subject">
+        <source>LABEL_ENTER_SUBJECT</source>
+        <target>Inserisci l'oggetto</target>
+      </trans-unit>
+      <trans-unit id="label_subject">
+        <source>LABEL_SUBJECT</source>
+        <target>Oggetto</target>
+      </trans-unit>
+      <trans-unit id="label_date_format">
+        <source>LABEL_DATE_FORMAT</source>
+        <target>d/m/Y</target>
+      </trans-unit>
+      <trans-unit id="label_date_time_format">
+        <source>LABEL_DATE_TIME_FORMAT</source>
+        <target>d/m/Y H:i:s</target>
+      </trans-unit>
+      <trans-unit id="message_no_tickets">
+        <source>MESSAGE_NO_TICKETS</source>
+        <target>Nessun ticket trovato</target>
+      </trans-unit>
+      <trans-unit id="message_empty">
+        <source>MESSAGE_EMPTY</source>
+        <target>-- Il messaggio è vuoto --</target>
+      </trans-unit>
+      <trans-unit id="message_ticket_opened">
+        <source>MESSAGE_TICKET_OPENED</source>
+        <target>Ticket aperto con priorità: %priority%.</target>
+      </trans-unit>
+      <trans-unit id="message_status_changed">
+        <source>MESSAGE_STATUS_CHANGED</source>
+        <target>Lo status è stato cambiato in %status%.</target>
+      </trans-unit>
+      <trans-unit id="message_priority_changed">
+        <source>MESSAGE_PRIORITY_CHANGED</source>
+        <target>La priority è stata cambiata in %priority%.</target>
+      </trans-unit>
+      <trans-unit id="error_find_ticket_entity">
+        <source>ERROR_FIND_TICKET_ENTITY</source>
+        <target>Impossible trovare il ticket.</target>
+      </trans-unit>
+      <trans-unit id="label_ticket_attachment">
+        <source>LABEL_ATTACHMENT</source>
+        <target>Allegato</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/translations/HackzillaTicketBundle.pt_BR.xlf
+++ b/Resources/translations/HackzillaTicketBundle.pt_BR.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="status_open">
+        <source>STATUS_OPEN</source>
+        <target>Aberto</target>
+      </trans-unit>
+      <trans-unit id="status_in_progress">
+        <source>STATUS_IN_PROGRESS</source>
+        <target>Em progresso</target>
+      </trans-unit>
+      <trans-unit id="status_information_requested">
+        <source>STATUS_INFORMATION_REQUESTED</source>
+        <target>Informação solicitada</target>
+      </trans-unit>
+      <trans-unit id="status_on_hold">
+        <source>STATUS_ON_HOLD</source>
+        <target>Em espera</target>
+      </trans-unit>
+      <trans-unit id="status_resolved">
+        <source>STATUS_RESOLVED</source>
+        <target>Resolvido</target>
+      </trans-unit>
+      <trans-unit id="status_closed">
+        <source>STATUS_CLOSED</source>
+        <target>Terminado</target>
+      </trans-unit>
+      <trans-unit id="priority_low">
+        <source>PRIORITY_LOW</source>
+        <target>Baixo</target>
+      </trans-unit>
+      <trans-unit id="priority_medium">
+        <source>PRIORITY_MEDIUM</source>
+        <target>Médio</target>
+      </trans-unit>
+      <trans-unit id="priority_high">
+        <source>PRIORITY_HIGH</source>
+        <target>Alta</target>
+      </trans-unit>
+      <trans-unit id="status_invalid">
+        <source>STATUS_INVALID</source>
+        <target>Inválido</target>
+      </trans-unit>
+      <trans-unit id="priority_invalid">
+        <source>PRIORITY_INVALID</source>
+        <target>Inválido</target>
+      </trans-unit>
+      <trans-unit id="heading_subject">
+        <source>HEADING_SUBJECT</source>
+        <target>Tema</target>
+      </trans-unit>
+      <trans-unit id="heading_status">
+        <source>HEADING_STATUS</source>
+        <target>Estado</target>
+      </trans-unit>
+      <trans-unit id="heading_priority">
+        <source>HEADING_PRIORITY</source>
+        <target>Prioridade</target>
+      </trans-unit>
+      <trans-unit id="heading_modified">
+        <source>HEADING_MODIFIED</source>
+        <target>Modificado em</target>
+      </trans-unit>
+      <trans-unit id="heading_created">
+        <source>HEADING_CREATED</source>
+        <target>Criado em</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_list">
+        <source>HEADING_TICKET_LIST</source>
+        <target>Lista de tarefas</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket">
+        <source>HEADING_TICKET</source>
+        <target>Tarefas</target>
+      </trans-unit>
+      <trans-unit id="heading_new_ticket">
+        <source>HEADING_NEW_TICKET</source>
+        <target>Nova tarefa</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_id">
+        <source>HEADING_TICKET_ID</source>
+        <target>Tarefa nº%id%</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_thread">
+        <source>HEADING_TICKET_THREAD</source>
+        <target>Diálogo</target>
+      </trans-unit>
+      <trans-unit id="heading_last_message_by">
+        <source>HEADING_LAST_MESSAGE_BY</source>
+        <target>Última mensagem da parte de</target>
+      </trans-unit>
+      <trans-unit id="heading_last_modified">
+        <source>HEADING_LAST_MODIFIED</source>
+        <target>Última modificação da parte de</target>
+      </trans-unit>
+      <trans-unit id="heading_author">
+        <source>HEADING_AUTHOR</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="button_delete">
+        <source>BUTTON_DELETE</source>
+        <target>Deletar</target>
+      </trans-unit>
+      <trans-unit id="button_back_to_list">
+        <source>BUTTON_BACK_TO_LIST</source>
+        <target>Voltar a lista</target>
+      </trans-unit>
+      <trans-unit id="button_update">
+        <source>BUTTON_UPDATE</source>
+        <target>Atualizar</target>
+      </trans-unit>
+      <trans-unit id="button_create">
+        <source>BUTTON_CREATE</source>
+        <target>Criar</target>
+      </trans-unit>
+      <trans-unit id="button_new">
+        <source>BUTTON_NEW</source>
+        <target>Novo</target>
+      </trans-unit>
+      <trans-unit id="button_toggle_state">
+        <source>BUTTON_TOGGLE_STATE</source>
+        <target>Mostrar as tarefas %state%s</target>
+      </trans-unit>
+      <trans-unit id="label_author">
+        <source>LABEL_AUTHOR</source>
+        <target>Autor</target>
+      </trans-unit>
+      <trans-unit id="label_date">
+        <source>LABEL_DATE</source>
+        <target>Data</target>
+      </trans-unit>
+      <trans-unit id="label_priority">
+        <source>LABEL_PRIORITY</source>
+        <target>Prioridade</target>
+      </trans-unit>
+      <trans-unit id="label_status">
+        <source>LABEL_STATUS</source>
+        <target>Estado</target>
+      </trans-unit>
+      <trans-unit id="label_message">
+        <source>LABEL_MESSAGE</source>
+        <target>Mensagem</target>
+      </trans-unit>
+      <trans-unit id="label_created">
+        <source>LABEL_CREATED</source>
+        <target>Criado em</target>
+      </trans-unit>
+      <trans-unit id="label_created_by">
+        <source>LABEL_CREATED_BY</source>
+        <target>Criado por</target>
+      </trans-unit>
+      <trans-unit id="label_admin">
+        <source>LABEL_ADMIN</source>
+        <target>Administrador</target>
+      </trans-unit>
+      <trans-unit id="label_mark_solved">
+        <source>LABEL_MARK_SOLVED</source>
+        <target>Identificar como resolvido</target>
+      </trans-unit>
+      <trans-unit id="label_enter_details">
+        <source>LABEL_ENTER_DETAILS</source>
+        <target>Ver mais detalhes</target>
+      </trans-unit>
+      <trans-unit id="label_enter_subject">
+        <source>LABEL_ENTER_SUBJECT</source>
+        <target>Entre em um tema</target>
+      </trans-unit>
+      <trans-unit id="label_subject">
+        <source>LABEL_SUBJECT</source>
+        <target>Tema</target>
+      </trans-unit>
+      <trans-unit id="label_date_format">
+        <source>LABEL_DATE_FORMAT</source>
+        <target>d/m/Y</target>
+      </trans-unit>
+      <trans-unit id="label_date_time_format">
+        <source>LABEL_DATE_TIME_FORMAT</source>
+        <target>d/m/Y H:i:s</target>
+      </trans-unit>
+      <trans-unit id="message_no_tickets">
+        <source>MESSAGE_NO_TICKETS</source>
+        <target>Nenhuma tarefa</target>
+      </trans-unit>
+      <trans-unit id="message_empty">
+        <source>MESSAGE_EMPTY</source>
+        <target>-- Mensagem vazia --</target>
+      </trans-unit>
+      <trans-unit id="message_ticket_opened">
+        <source>MESSAGE_TICKET_OPENED</source>
+        <target>Tarefa criada como %priority% prioridade.</target>
+      </trans-unit>
+      <trans-unit id="message_status_changed">
+        <source>MESSAGE_STATUS_CHANGED</source>
+        <target>Estado modificado: %status%.</target>
+      </trans-unit>
+      <trans-unit id="message_priority_changed">
+        <source>MESSAGE_PRIORITY_CHANGED</source>
+        <target>Prioridade modificada: %priority%.</target>
+      </trans-unit>
+      <trans-unit id="error_find_ticket_entity">
+        <source>ERROR_FIND_TICKET_ENTITY</source>
+        <target>Nenhuma tarefa encontrada.</target>
+      </trans-unit>
+      <trans-unit id="label_ticket_attachment">
+        <source>LABEL_ATTACHMENT</source>
+        <target>Anexo</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/translations/HackzillaTicketBundle.ru.xlf
+++ b/Resources/translations/HackzillaTicketBundle.ru.xlf
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="status_open">
+        <source>STATUS_OPEN</source>
+        <target>Открыто</target>
+      </trans-unit>
+      <trans-unit id="status_in_progress">
+        <source>STATUS_IN_PROGRESS</source>
+        <target>В обработке</target>
+      </trans-unit>
+      <trans-unit id="status_information_requested">
+        <source>STATUS_INFORMATION_REQUESTED</source>
+        <target>Информация запрошена</target>
+      </trans-unit>
+      <trans-unit id="status_on_hold">
+        <source>STATUS_ON_HOLD</source>
+        <target>Заморожено</target>
+      </trans-unit>
+      <trans-unit id="status_resolved">
+        <source>STATUS_RESOLVED</source>
+        <target>Выполнено</target>
+      </trans-unit>
+      <trans-unit id="status_closed">
+        <source>STATUS_CLOSED</source>
+        <target>Закрыто</target>
+      </trans-unit>
+      <trans-unit id="priority_low">
+        <source>PRIORITY_LOW</source>
+        <target>Низкий</target>
+      </trans-unit>
+      <trans-unit id="priority_medium">
+        <source>PRIORITY_MEDIUM</source>
+        <target>Средний</target>
+      </trans-unit>
+      <trans-unit id="priority_high">
+        <source>PRIORITY_HIGH</source>
+        <target>Высокий</target>
+      </trans-unit>
+      <trans-unit id="status_invalid">
+        <source>STATUS_INVALID</source>
+        <target>Неверный статус</target>
+      </trans-unit>
+      <trans-unit id="priority_invalid">
+        <source>PRIORITY_INVALID</source>
+        <target>Неверный приоритет</target>
+      </trans-unit>
+      <trans-unit id="heading_subject">
+        <source>HEADING_SUBJECT</source>
+        <target>Тема</target>
+      </trans-unit>
+      <trans-unit id="heading_status">
+        <source>HEADING_STATUS</source>
+        <target>Статус</target>
+      </trans-unit>
+      <trans-unit id="heading_priority">
+        <source>HEADING_PRIORITY</source>
+        <target>Приоритет</target>
+      </trans-unit>
+      <trans-unit id="heading_modified">
+        <source>HEADING_MODIFIED</source>
+        <target>Изменено</target>
+      </trans-unit>
+      <trans-unit id="heading_created">
+        <source>HEADING_CREATED</source>
+        <target>Создано</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_list">
+        <source>HEADING_TICKET_LIST</source>
+        <target>Список обращений</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket">
+        <source>HEADING_TICKET</source>
+        <target>Ticket</target>
+      </trans-unit>
+      <trans-unit id="heading_new_ticket">
+        <source>HEADING_NEW_TICKET</source>
+        <target>Новое обращение</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_id">
+        <source>HEADING_TICKET_ID</source>
+        <target>Обращение #%id%</target>
+      </trans-unit>
+      <trans-unit id="heading_ticket_thread">
+        <source>HEADING_TICKET_THREAD</source>
+        <target>Сообщения</target>
+      </trans-unit>
+      <trans-unit id="heading_last_message_by">
+        <source>HEADING_LAST_MESSAGE_BY</source>
+        <target>Последнее сообщение от </target>
+      </trans-unit>
+      <trans-unit id="heading_last_modified">
+        <source>HEADING_LAST_MODIFIED</source>
+        <target>Последнее изменение</target>
+      </trans-unit>
+      <trans-unit id="heading_author">
+        <source>HEADING_AUTHOR</source>
+        <target>Автор</target>
+      </trans-unit>
+      <trans-unit id="button_delete">
+        <source>BUTTON_DELETE</source>
+        <target>Удалить</target>
+      </trans-unit>
+      <trans-unit id="button_back_to_list">
+        <source>BUTTON_BACK_TO_LIST</source>
+        <target>Обратно к списку</target>
+      </trans-unit>
+      <trans-unit id="button_update">
+        <source>BUTTON_UPDATE</source>
+        <target>Обновить</target>
+      </trans-unit>
+      <trans-unit id="button_create">
+        <source>BUTTON_CREATE</source>
+        <target>Создать</target>
+      </trans-unit>
+      <trans-unit id="button_new">
+        <source>BUTTON_NEW</source>
+        <target>Новое обращение</target>
+      </trans-unit>
+      <trans-unit id="button_toggle_state">
+        <source>BUTTON_TOGGLE_STATE</source>
+        <target>Показать обращения со статусом %state%</target>
+      </trans-unit>
+      <trans-unit id="label_author">
+        <source>LABEL_AUTHOR</source>
+        <target>Автор</target>
+      </trans-unit>
+      <trans-unit id="label_date">
+        <source>LABEL_DATE</source>
+        <target>Дата</target>
+      </trans-unit>
+      <trans-unit id="label_priority">
+        <source>LABEL_PRIORITY</source>
+        <target>Приоритет</target>
+      </trans-unit>
+      <trans-unit id="label_status">
+        <source>LABEL_STATUS</source>
+        <target>Статус</target>
+      </trans-unit>
+      <trans-unit id="label_message">
+        <source>LABEL_MESSAGE</source>
+        <target>Сообщение</target>
+      </trans-unit>
+      <trans-unit id="label_created">
+        <source>LABEL_CREATED</source>
+        <target>Создано</target>
+      </trans-unit>
+      <trans-unit id="label_created_by">
+        <source>LABEL_CREATED_BY</source>
+        <target>Создано </target>
+      </trans-unit>
+      <trans-unit id="label_admin">
+        <source>LABEL_ADMIN</source>
+        <target>Администратор</target>
+      </trans-unit>
+      <trans-unit id="label_mark_solved">
+        <source>LABEL_MARK_SOLVED</source>
+        <target>Пометить как "решено"</target>
+      </trans-unit>
+      <trans-unit id="label_enter_details">
+        <source>LABEL_ENTER_DETAILS</source>
+        <target>Детали</target>
+      </trans-unit>
+      <trans-unit id="label_enter_subject">
+        <source>LABEL_ENTER_SUBJECT</source>
+        <target>Тема обращения</target>
+      </trans-unit>
+      <trans-unit id="label_subject">
+        <source>LABEL_SUBJECT</source>
+        <target>Тема</target>
+      </trans-unit>
+      <trans-unit id="label_date_format">
+        <source>LABEL_DATE_FORMAT</source>
+        <target>Y/m/d</target>
+      </trans-unit>
+      <trans-unit id="label_date_time_format">
+        <source>LABEL_DATE_TIME_FORMAT</source>
+        <target>Y/m/d H:i:s</target>
+      </trans-unit>
+      <trans-unit id="message_no_tickets">
+        <source>MESSAGE_NO_TICKETS</source>
+        <target>Нет обращений</target>
+      </trans-unit>
+      <trans-unit id="message_empty">
+        <source>MESSAGE_EMPTY</source>
+        <target>-- Пустое сообщение --</target>
+      </trans-unit>
+      <trans-unit id="message_ticket_opened">
+        <source>MESSAGE_TICKET_OPENED</source>
+        <target>Обращение открыто с приоритетом: %priority%.</target>
+      </trans-unit>
+      <trans-unit id="message_status_changed">
+        <source>MESSAGE_STATUS_CHANGED</source>
+        <target>Статус был изменен на %status%.</target>
+      </trans-unit>
+      <trans-unit id="message_priority_changed">
+        <source>MESSAGE_PRIORITY_CHANGED</source>
+        <target>Приоритет был изменен на %priority%.</target>
+      </trans-unit>
+      <trans-unit id="error_find_ticket_entity">
+        <source>ERROR_FIND_TICKET_ENTITY</source>
+        <target>Не вышло найти обращение.</target>
+      </trans-unit>
+      <trans-unit id="label_ticket_attachment">
+        <source>LABEL_ATTACHMENT</source>
+        <target>прикрепление</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/views/Macros/macros.html.twig
+++ b/Resources/views/Macros/macros.html.twig
@@ -1,4 +1,4 @@
-{% macro status_btn(status, text, small = false) %}
+{% macro status_btn(status, text, small = false, translationDomain = 'messages') %}
     {% spaceless %}
         {% if status == 10 %}
             <button class="btn btn-warning {{ small ? 'btn-xs' : '' }} disabled active"><span
@@ -22,34 +22,34 @@
     {% endspaceless %}
 {% endmacro %}
 
-{% macro status_alert(status, text) %}
+{% macro status_alert(status, text, translationDomain = 'messages') %}
     {% spaceless %}
         {% if status == 10 %}
-            <div class="alert alert-warning" role="alert"><span class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }) }}
+            <div class="alert alert-warning" role="alert"><span class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% elseif status == 11 %}
             <div class="alert alert-info" role="alert"><span
-                        class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }) }}
+                        class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% elseif status == 12 %}
             <div class="alert alert-info" role="alert"><span
-                        class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }) }}
+                        class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% elseif status == 13 %}
             <div class="alert alert-info" role="alert"><span
-                        class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }) }}
+                        class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% elseif status == 14 %}
-            <div class="alert alert-success" role="alert"><span class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }) }}
+            <div class="alert alert-success" role="alert"><span class="glyphicon glyphicon-folder-open"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% elseif status == 15 %}
-            <div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-folder-close"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }) }}
+            <div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon-folder-close"></span>&nbsp;&nbsp;{{ 'MESSAGE_STATUS_CHANGED'|trans({'%status%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% endif %}
     {% endspaceless %}
 {% endmacro %}
 
-{% macro priority_btn(priority, text, small = false) %}
+{% macro priority_btn(priority, text, small = false, translationDomain = 'messages') %}
     {% spaceless %}
         {% if priority <= 20 %}
             <button class="btn btn-info {{ small ? 'btn-xs' : '' }} disabled active">{{ text|upper }}</button>
@@ -63,18 +63,18 @@
     {% endspaceless %}
 {% endmacro %}
 
-{% macro priority_alert(priority, text) %}
+{% macro priority_alert(priority, text, translationDomain = 'messages') %}
     {% spaceless %}
         {% if priority <= 20 %}
             <div class="alert alert-info"
-                 role="alert">{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }) }}</div>
+                 role="alert">{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }, translationDomain|default('messages')) }}</div>
         {% elseif priority == 21 %}
             <div class="alert alert-warning" role="alert"><span
-                        class="glyphicon glyphicon-asterisk"></span>&nbsp;&nbsp;{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }) }}
+                        class="glyphicon glyphicon-asterisk"></span>&nbsp;&nbsp;{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% else %}
             <div class="alert alert-danger" role="alert"><span
-                        class="glyphicon glyphicon-star"></span>&nbsp;&nbsp;{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }) }}
+                        class="glyphicon glyphicon-star"></span>&nbsp;&nbsp;{{ 'MESSAGE_PRIORITY_CHANGED'|trans({'%priority%': text|upper }, translationDomain|default('messages')) }}
             </div>
         {% endif %}
     {% endspaceless %}

--- a/Resources/views/Ticket/index.html.twig
+++ b/Resources/views/Ticket/index.html.twig
@@ -2,15 +2,15 @@
 {% import hackzilla_ticket.templates.macros as macros %}
 
 {% block hackzilla_ticket_content -%}
-    <h1>{{ 'HEADING_TICKET_LIST'|trans }}</h1>
+    <h1>{{ 'HEADING_TICKET_LIST'|trans({}, translationDomain|default('messages')) }}</h1>
 
     <div class="row">
         <div class="col-xs-4">
             <div class="btn-group">
-                <a href="{{ path('hackzilla_ticket', {'state': 'STATUS_OPEN'|trans}) }}"
-                   class="btn btn-default {{ ticketState != 'STATUS_CLOSED'|trans ? 'active' : '' }}">{{ 'STATUS_OPEN'|trans|upper }}</a>
-                <a href="{{ path('hackzilla_ticket', {'state': 'STATUS_CLOSED'|trans}) }}"
-                   class="btn btn-default {{ ticketState == 'STATUS_CLOSED'|trans ? 'active' : '' }}">{{ 'STATUS_CLOSED'|trans|upper }}</a>
+                <a href="{{ path('hackzilla_ticket', {'state': 'STATUS_OPEN'|trans({}, translationDomain|default('messages'))}) }}"
+                   class="btn btn-default {{ ticketState != 'STATUS_CLOSED'|trans({}, translationDomain|default('messages')) ? 'active' : '' }}">{{ 'STATUS_OPEN'|trans({}, translationDomain|default('messages'))|upper }}</a>
+                <a href="{{ path('hackzilla_ticket', {'state': 'STATUS_CLOSED'|trans({}, translationDomain|default('messages'))}) }}"
+                   class="btn btn-default {{ ticketState == 'STATUS_CLOSED'|trans({}, translationDomain|default('messages')) ? 'active' : '' }}">{{ 'STATUS_CLOSED'|trans({}, translationDomain|default('messages'))|upper }}</a>
             </div>
         </div>
 
@@ -19,19 +19,19 @@
                 <a href="{{ path('hackzilla_ticket') }}"
                    class="btn btn-default {{ ticketPriority is null ? 'active' : '' }}"><span
                             class="glyphicon glyphicon-remove"></span></a>
-                <a href="{{ path('hackzilla_ticket', {'priority': 'PRIORITY_HIGH'|trans}) }}"
-                   class="btn btn-danger {{ ticketPriority == 'PRIORITY_HIGH'|trans ? 'active' : '' }}">{{ 'PRIORITY_HIGH'|trans|upper }}</a>
-                <a href="{{ path('hackzilla_ticket', {'priority': 'PRIORITY_MEDIUM'|trans}) }}"
-                   class="btn btn-warning {{ ticketPriority == 'PRIORITY_MEDIUM'|trans ? 'active' : '' }}">{{ 'PRIORITY_MEDIUM'|trans|upper }}</a>
-                <a href="{{ path('hackzilla_ticket', {'priority': 'PRIORITY_LOW'|trans}) }}"
-                   class="btn btn-info {{ ticketPriority == 'PRIORITY_LOW'|trans ? 'active' : '' }}">{{ 'PRIORITY_LOW'|trans|upper }}</a>
+                <a href="{{ path('hackzilla_ticket', {'priority': 'PRIORITY_HIGH'|trans({}, translationDomain|default('messages'))}) }}"
+                   class="btn btn-danger {{ ticketPriority == 'PRIORITY_HIGH'|trans({}, translationDomain|default('messages')) ? 'active' : '' }}">{{ 'PRIORITY_HIGH'|trans({}, translationDomain|default('messages'))|upper }}</a>
+                <a href="{{ path('hackzilla_ticket', {'priority': 'PRIORITY_MEDIUM'|trans({}, translationDomain|default('messages'))}) }}"
+                   class="btn btn-warning {{ ticketPriority == 'PRIORITY_MEDIUM'|trans({}, translationDomain|default('messages')) ? 'active' : '' }}">{{ 'PRIORITY_MEDIUM'|trans({}, translationDomain|default('messages'))|upper }}</a>
+                <a href="{{ path('hackzilla_ticket', {'priority': 'PRIORITY_LOW'|trans({}, translationDomain|default('messages'))}) }}"
+                   class="btn btn-info {{ ticketPriority == 'PRIORITY_LOW'|trans({}, translationDomain|default('messages')) ? 'active' : '' }}">{{ 'PRIORITY_LOW'|trans({}, translationDomain|default('messages'))|upper }}</a>
             </div>
         </div>
 
         <div class="col-xs-4 text-right">
             <div class="btn-group">
                 <a href="{{ path('hackzilla_ticket_new') }}" class="btn btn-primary"><span
-                            class="glyphicon glyphicon-plus"></span> {{ 'BUTTON_NEW'|trans }}</a>
+                            class="glyphicon glyphicon-plus"></span> {{ 'BUTTON_NEW'|trans({}, translationDomain|default('messages')) }}</a>
             </div>
         </div>
     </div>
@@ -39,13 +39,13 @@
     <table class="table table-bordered table-striped">
         <thead>
         <tr>
-            <th class="col-xs-1">{{ knp_pagination_sortable(pagination, 'HEADING_TICKET'|trans, 't.id') }}</th>
-            <th{% if pagination.isSorted('t.subject') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_SUBJECT'|trans, 't.subject') }}</th>
-            <th{% if pagination.isSorted('t.userCreated') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_AUTHOR'|trans, 't.userCreated') }}</th>
-            <th{% if pagination.isSorted('t.status') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_STATUS'|trans, 't.status') }}</th>
-            <th{% if pagination.isSorted('t.priority') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_PRIORITY'|trans, 't.priority') }}</th>
-            <th{% if pagination.isSorted('t.modified') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_MODIFIED'|trans, 't.lastMessage') }}</th>
-            <th{% if pagination.isSorted('t.created') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_CREATED'|trans, 't.createdAt') }}</th>
+            <th class="col-xs-1">{{ knp_pagination_sortable(pagination, 'HEADING_TICKET'|trans({}, translationDomain|default('messages')), 't.id') }}</th>
+            <th{% if pagination.isSorted('t.subject') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_SUBJECT'|trans({}, translationDomain|default('messages')), 't.subject') }}</th>
+            <th{% if pagination.isSorted('t.userCreated') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_AUTHOR'|trans({}, translationDomain|default('messages')), 't.userCreated') }}</th>
+            <th{% if pagination.isSorted('t.status') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_STATUS'|trans({}, translationDomain|default('messages')), 't.status') }}</th>
+            <th{% if pagination.isSorted('t.priority') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_PRIORITY'|trans({}, translationDomain|default('messages')), 't.priority') }}</th>
+            <th{% if pagination.isSorted('t.modified') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_MODIFIED'|trans({}, translationDomain|default('messages')), 't.lastMessage') }}</th>
+            <th{% if pagination.isSorted('t.created') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_CREATED'|trans({}, translationDomain|default('messages')), 't.createdAt') }}</th>
         </tr>
         </thead>
         <tbody>
@@ -54,14 +54,14 @@
                 <td><a href="{{ path('hackzilla_ticket_show', { 'ticketId': entity.id }) }}">{{ entity.id }}</a></td>
                 <td><a href="{{ path('hackzilla_ticket_show', { 'ticketId': entity.id }) }}">{{ entity.subject }}</a></td>
                 <td>{{ entity.userCreatedObject }}</td>
-                <td>{{ macros.status_btn(entity.status, entity.statusString|trans, true) }}</td>
-                <td>{{ macros.priority_btn(entity.priority, entity.priorityString|trans, true) }}</td>
-                <td>{% if entity.lastMessage %}{{ entity.lastMessage|date('LABEL_DATE_TIME_FORMAT'|trans) }}{% endif %}</td>
-                <td>{% if entity.createdAt %}{{ entity.createdAt|date('LABEL_DATE_TIME_FORMAT'|trans) }}{% endif %}</td>
+                <td>{{ macros.status_btn(entity.status, entity.statusString|trans({}, translationDomain|default('messages')), true, translationDomain) }}</td>
+                <td>{{ macros.priority_btn(entity.priority, entity.priorityString|trans({}, translationDomain|default('messages')), true, translationDomain) }}</td>
+                <td>{% if entity.lastMessage %}{{ entity.lastMessage|date('LABEL_DATE_TIME_FORMAT'|trans({}, translationDomain|default('messages'))) }}{% endif %}</td>
+                <td>{% if entity.createdAt %}{{ entity.createdAt|date('LABEL_DATE_TIME_FORMAT'|trans({}, translationDomain|default('messages'))) }}{% endif %}</td>
             </tr>
         {% else %}
             <tr>
-                <td colspan="7">{{ 'MESSAGE_NO_TICKETS'|trans }}.</td>
+                <td colspan="7">{{ 'MESSAGE_NO_TICKETS'|trans({}, translationDomain|default('messages')) }}.</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/Resources/views/Ticket/new.html.twig
+++ b/Resources/views/Ticket/new.html.twig
@@ -1,7 +1,7 @@
 {% extends '@HackzillaTicket/layout.html.twig' %}
 
 {% block hackzilla_ticket_content -%}
-    <h1>{{ 'HEADING_NEW_TICKET'|trans }}</h1>
+    <h1>{{ 'HEADING_NEW_TICKET'|trans({}, translationDomain|default('messages')) }}</h1>
 
     <div class="well well-sm">
         {{ form_start(form, {'method': 'POST', 'action': path('hackzilla_ticket_create')}) }}
@@ -23,10 +23,10 @@
 
             <div class="form-group row">
                 <div class="col-lg-offset-2 col-lg-10 col-md-offset-2 col-md-10 col-sm-offset-2 col-sm-10">
-                    <button type="submit" class="btn btn-primary">{{ 'BUTTON_CREATE'|trans }}</button>
+                    <button type="submit" class="btn btn-primary">{{ 'BUTTON_CREATE'|trans({}, translationDomain|default('messages')) }}</button>
 
                     <a href="{{ path('hackzilla_ticket') }}" class="btn btn-default">
-                        {{ 'BUTTON_BACK_TO_LIST'|trans }}
+                        {{ 'BUTTON_BACK_TO_LIST'|trans({}, translationDomain|default('messages')) }}
                     </a>
                 </div>
             </div>

--- a/Resources/views/Ticket/show.html.twig
+++ b/Resources/views/Ticket/show.html.twig
@@ -4,48 +4,48 @@
 {% block hackzilla_ticket_content -%}
 
     <p>
-        <a href="{{ path('hackzilla_ticket') }}" class="btn btn-default">{{ 'BUTTON_BACK_TO_LIST'|trans }}</a>
+        <a href="{{ path('hackzilla_ticket') }}" class="btn btn-default">{{ 'BUTTON_BACK_TO_LIST'|trans({}, translationDomain|default('messages')) }}</a>
     </p>
 
     <h1>
-        {{ macros.status_btn(ticket.status, ticket.statusString|trans) }}
-        {{ macros.priority_btn(ticket.priority, ticket.priorityString|trans) }}
+        {{ macros.status_btn(ticket.status, ticket.statusString|trans({}, translationDomain|default('messages')), false, translationDomain) }}
+        {{ macros.priority_btn(ticket.priority, ticket.priorityString|trans({}, translationDomain|default('messages')), false, translationDomain) }}
         <small>#{{ ticket.id }}</small>
         - {{ ticket.subject }}
     </h1>
 
     <p>
-        <i>{{ 'LABEL_CREATED_BY'|trans }} {{ ticket.userCreatedObject }}
-            , {{ ticket.createdAt|date('LABEL_DATE_FORMAT'|trans) }}</i>
-        {# <br />{{ 'LABEL_PRIORITY'|trans }} <span class="label label-{{ ticket.priority == 0 ? 'default' : (ticket.priority == 20 ? 'primary' : (ticket.priority == 21 ? 'warning' : 'danger')) }}">{{ ticket.priorityString|trans }}</span> #}
+        <i>{{ 'LABEL_CREATED_BY'|trans({}, translationDomain|default('messages')) }} {{ ticket.userCreatedObject }}
+            , {{ ticket.createdAt|date('LABEL_DATE_FORMAT'|trans({}, translationDomain|default('messages'))) }}</i>
+        {# <br />{{ 'LABEL_PRIORITY'|trans({}, translationDomain|default('messages')) }} <span class="label label-{{ ticket.priority == 0 ? 'default' : (ticket.priority == 20 ? 'primary' : (ticket.priority == 21 ? 'warning' : 'danger')) }}">{{ ticket.priorityString|trans({}, translationDomain|default('messages')) }}</span> #}
     </p>
 
 
-    {# <h3>{{ 'HEADING_TICKET_THREAD'|trans }}</h3> #}
+    {# <h3>{{ 'HEADING_TICKET_THREAD'|trans({}, translationDomain|default('messages')) }}</h3> #}
     {% set previousStatus = null %}
     {% set previousPriority = null %}
 
     {% for message in ticket.messages %}
 
         {% if previousStatus and previousStatus != message.status %}
-            {{ macros.status_alert(message.status, message.statusString|trans) }}
+            {{ macros.status_alert(message.status, message.statusString|trans({}, translationDomain|default('messages')), translationDomain) }}
         {% endif %}
 
         {% if previousPriority and previousPriority != message.priority %}
-            {{ macros.priority_alert(message.priority, message.priorityString|trans) }}
+            {{ macros.priority_alert(message.priority, message.priorityString|trans({}, translationDomain|default('messages')), translationDomain) }}
         {% endif %}
 
         {% if message.message|length > 0 %}
             <div class="panel panel-default">
                 <div class="panel-heading">
                     {{ message.userObject }}
-                    {# <br />{{ 'LABEL_PRIORITY'|trans }} <span class="label label-{{ message.priority == 0 ? 'default' : (message.priority == 20 ? 'primary' : (message.priority == 21 ? 'warning' : 'danger')) }}">{{ message.priorityString|trans }}</span> #}
-                    {# <br />{{ 'LABEL_STATUS'|trans }} <span class="label label-{{ message.status ? 'success' : 'danger' }}">{{ message.statusString|trans }}</span> #}
+                    {# <br />{{ 'LABEL_PRIORITY'|trans({}, translationDomain|default('messages')) }} <span class="label label-{{ message.priority == 0 ? 'default' : (message.priority == 20 ? 'primary' : (message.priority == 21 ? 'warning' : 'danger')) }}">{{ message.priorityString|trans({}, translationDomain|default('messages')) }}</span> #}
+                    {# <br />{{ 'LABEL_STATUS'|trans({}, translationDomain|default('messages')) }} <span class="label label-{{ message.status ? 'success' : 'danger' }}">{{ message.statusString|trans({}, translationDomain|default('messages')) }}</span> #}
 
                     <span class="pull-right">
                 {% if message.userObject != ticket.userCreatedObject %}<span
-                        class="label label-danger">{{ 'LABEL_ADMIN'|trans }}</span> {% endif %}
-                        <small><i>{{ message.createdAt|date('LABEL_DATE_TIME_FORMAT'|trans) }}</i></small>
+                        class="label label-danger">{{ 'LABEL_ADMIN'|trans({}, translationDomain|default('messages')) }}</span> {% endif %}
+                        <small><i>{{ message.createdAt|date('LABEL_DATE_TIME_FORMAT'|trans({}, translationDomain|default('messages'))) }}</i></small>
             </span>
                 </div>
                 <div class="panel-body">
@@ -71,7 +71,7 @@
             {{ form_rest(form) }}
 
             <p class="form_actions">
-                <button type="submit" class="btn btn-primary">{{ 'BUTTON_UPDATE'|trans }}</button>
+                <button type="submit" class="btn btn-primary">{{ 'BUTTON_UPDATE'|trans({}, translationDomain|default('messages')) }}</button>
             </p>
             {{ form_end(form) }}
         </div>
@@ -82,7 +82,7 @@
         <input type="hidden" name="_method" value="DELETE"/>
         {{ form_widget(delete_form) }}
 
-        <button type="submit" class="btn btn-danger">{{ 'BUTTON_DELETE'|trans }}</button>
+        <button type="submit" class="btn btn-danger">{{ 'BUTTON_DELETE'|trans({}, translationDomain|default('messages')) }}</button>
         {{ form_end(delete_form) }}
     {% endif %}
 

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -121,7 +121,8 @@ class TestKernel extends Kernel
 
         // HackzillaBundle config
         $c->loadFromExtension('hackzilla_ticket', [
-            'user_class' => User::class,
+            'user_class'         => User::class,
+            'translation_domain' => 'HackzillaTicketBundle',
         ]);
 
         if ($this->useVichUploaderBundle) {

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,3 +1,21 @@
+UPGRADE FROM 3.3 to 3.4
+=======================
+
+## Translation domain
+
+ * Using "messages" translation domain is deprecated in favor of "HackzillaTicketBundle"
+   in order to allow projects consuming this bundle to override translations in
+   a proper way.
+   You should configure "hackzilla_ticket.translation_domain" with the value "HackzillaTicketBundle",
+   which will be the only allowed value in version 4.0.
+
+```yml
+# packages/hackzilla_ticket.yaml
+
+hackzilla_ticket:
+    translation_domain: HackzillaTicketBundle
+```
+
 UPGRADE FROM 3.2 to 3.3
 =======================
 


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Branch       |3.x|
|Bug fix?     |no |
|New feature? |no |
|BC breaks?   |no |
|Deprecations?|yes|
|Tests pass?  |yes|
|Fixed tickets|n/a|
|License      |MIT|
|Doc PR       |n/a|
                   

This is a backport from PR #123.