### PR TITLE
Mark `FunctionalTest::testConfiguredFileUploadSubscriber()` as skipped if "vich/uploader-bundle" is not available

### DIFF
--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -61,6 +61,10 @@ final class FunctionalTest extends WebTestCase
      */
     public function testConfiguredFileUploadSubscriber()
     {
+        if (!class_exists(Events::class)) {
+            $this->markTestSkipped(sprintf('%s() requires vich/uploader-bundle to be installed.', __METHOD__));
+        }
+
         $eventDispatcher = static::$kernel->getContainer()->get('event_dispatcher');
         $listeners = $eventDispatcher->getListeners();
 


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Branch       |3.x|
|Bug fix?     |no |
|New feature? |no |
|BC breaks?   |no |
|Deprecations?|no |
|Tests pass?  |yes|
|Fixed tickets|n/a |
|License      |MIT|
|Doc PR       |n/a |