### PR TITLE
Remove `serialize()` and `unserialize()` methods from `TestKernel`

### DIFF
--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -81,16 +81,6 @@ final class TestKernel extends Kernel
         return $this->getBaseDir().'log';
     }
 
-    public function serialize()
-    {
-        return serialize($this->useVichUploaderBundle);
-    }
-
-    public function unserialize($str)
-    {
-        $this->__construct(unserialize($str));
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 0
+    level: 1
     paths:
         - .
     excludes_analyse:


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Branch       |3.x|
|Bug fix?     |no |
|New feature? |no |
|BC breaks?   |no |
|Deprecations?|no |
|Tests pass?  |yes|
|Fixed tickets|n/a|
|License      |MIT|
|Doc PR       |n/a|